### PR TITLE
feat(proof): add Full Swing visual triage artifact

### DIFF
--- a/public/images/projects/full-swing-triage-artifact.svg
+++ b/public/images/projects/full-swing-triage-artifact.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Full Swing troubleshooting workflow artifact">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b1020"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect x="48" y="48" width="1104" height="579" rx="18" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+
+  <text x="84" y="110" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="34" font-weight="700">
+    Full Swing Support: Branch-Based Triage Artifact
+  </text>
+  <text x="84" y="146" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="20">
+    Representative production workflow used to isolate multi-layer simulator failures.
+  </text>
+
+  <rect x="84" y="186" width="194" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="181" y="231" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Classify symptoms</text>
+
+  <rect x="320" y="186" width="194" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="417" y="231" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Build baseline</text>
+
+  <rect x="556" y="186" width="194" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="653" y="231" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Branch testing</text>
+
+  <rect x="792" y="186" width="194" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="889" y="231" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Apply low-risk fix</text>
+
+  <line x1="278" y1="222" x2="320" y2="222" stroke="url(#accent)" stroke-width="3"/>
+  <line x1="514" y1="222" x2="556" y2="222" stroke="url(#accent)" stroke-width="3"/>
+  <line x1="750" y1="222" x2="792" y2="222" stroke="url(#accent)" stroke-width="3"/>
+
+  <rect x="84" y="304" width="420" height="248" rx="12" fill="#111827" stroke="#374151"/>
+  <text x="108" y="340" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22" font-weight="600">
+    Failure branches checked
+  </text>
+  <text x="108" y="380" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">- Calibration state and drift</text>
+  <text x="108" y="414" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">- Licensing and activation path</text>
+  <text x="108" y="448" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">- Display and GPU pipeline</text>
+  <text x="108" y="482" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">- Network and environment config</text>
+  <text x="108" y="516" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">- Peripheral and OS interaction</text>
+
+  <rect x="534" y="304" width="618" height="248" rx="12" fill="#111827" stroke="#374151"/>
+  <text x="558" y="340" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22" font-weight="600">
+    Outcome signal
+  </text>
+  <text x="558" y="382" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">
+    Replaced ad hoc fixes with repeatable triage paths.
+  </text>
+  <text x="558" y="416" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">
+    Faster recurring-issue resolution through documented branch elimination.
+  </text>
+  <text x="558" y="450" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18">
+    Improved consistency under mixed hardware/software/network constraints.
+  </text>
+  <text x="558" y="514" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15">
+    Artifact source: /projects/full-swing-tech-support case study
+  </text>
+</svg>

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -148,6 +148,7 @@ export const projects: Project[] = [
       "Networking",
       "Hardware/Software Integration",
     ],
+    image: "/images/projects/full-swing-triage-artifact.svg",
     caseStudy: "/projects/full-swing-tech-support",
     category: "featured",
   },


### PR DESCRIPTION
Add a concrete visual proof artifact for the Full Swing featured project card and wire it through projects data so the homepage and projects grid show evidence-backed imagery instead of fallback placeholders.