### PR TITLE
feat(resume): add public evidence links to experience highlights

### DIFF
--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -7,6 +7,7 @@ import {
   resumeExperience,
   resumeSkills,
   resumeSummary,
+  type ResumeHighlight,
 } from "@/content/resume";
 import { getPublicContactEmail } from "@/lib/site-contact";
 
@@ -15,6 +16,25 @@ export const metadata: Metadata = {
   description:
     "Resume for Matt Maitland covering full-stack development and technical support experience.",
 };
+
+function HighlightText({ highlight }: { highlight: ResumeHighlight }) {
+  if (!highlight.href) {
+    return <>{highlight.text}</>;
+  }
+
+  const isExternal = /^https?:\/\//.test(highlight.href);
+
+  return (
+    <a
+      href={highlight.href}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
+      className="underline decoration-purple-500/50 underline-offset-4 transition-colors hover:text-foreground"
+    >
+      {highlight.text}
+    </a>
+  );
+}
 
 export default function ResumePage() {
   const publicEmail = getPublicContactEmail();
@@ -75,6 +95,18 @@ export default function ResumePage() {
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
                   {item.description}
                 </p>
+                {item.highlights && item.highlights.length > 0 && (
+                  <ul className="mt-3 space-y-1">
+                    {item.highlights.map((highlight, index) => (
+                      <li
+                        key={`${highlight.text}-${index}`}
+                        className="text-sm text-muted-foreground pl-3 relative before:absolute before:left-0 before:top-[0.6em] before:h-1 before:w-1 before:rounded-full before:bg-purple-500/50"
+                      >
+                        <HighlightText highlight={highlight} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </article>
             ))}
           </div>

--- a/src/components/sections/about-content.tsx
+++ b/src/components/sections/about-content.tsx
@@ -18,6 +18,7 @@ import {
   resumeExperience as experience,
   resumeEducation as education,
   resumeCertifications as certifications,
+  type ResumeHighlight,
 } from "@/content/resume";
 
 type AboutContentProps = {
@@ -30,6 +31,25 @@ const fadeUp = {
   viewport: { once: true as const },
   transition: { duration: 0.5 },
 };
+
+function HighlightText({ highlight }: { highlight: ResumeHighlight }) {
+  if (!highlight.href) {
+    return <>{highlight.text}</>;
+  }
+
+  const isExternal = /^https?:\/\//.test(highlight.href);
+
+  return (
+    <a
+      href={highlight.href}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
+      className="underline decoration-purple-500/50 underline-offset-4 transition-colors hover:text-foreground"
+    >
+      {highlight.text}
+    </a>
+  );
+}
 
 export function AboutContent({ publicEmail }: AboutContentProps) {
   return (
@@ -100,12 +120,12 @@ export function AboutContent({ publicEmail }: AboutContentProps) {
               </p>
               {exp.highlights && exp.highlights.length > 0 && (
                 <ul className="mt-2 space-y-1">
-                  {exp.highlights.map((h) => (
+                  {exp.highlights.map((highlight, index) => (
                     <li
-                      key={h}
+                      key={`${highlight.text}-${index}`}
                       className="text-sm text-muted-foreground pl-3 relative before:absolute before:left-0 before:top-[0.6em] before:h-1 before:w-1 before:rounded-full before:bg-purple-500/50"
                     >
-                      {h}
+                      <HighlightText highlight={highlight} />
                     </li>
                   ))}
                 </ul>

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -5,6 +5,19 @@ export const contactInfo = {
   github: "https://github.com/mmaitland300",
 };
 
+export type ResumeHighlight = {
+  text: string;
+  href?: string;
+};
+
+export type ResumeExperienceItem = {
+  role: string;
+  company: string;
+  period: string;
+  description: string;
+  highlights?: ResumeHighlight[];
+};
+
 export const resumeSummary =
   "Colorado-based developer and technical support professional focused on practical software, reliable systems, and clear problem solving. Experience includes building full-stack web applications, integrating APIs, deploying production systems, and supporting users through hardware, software, and connectivity issues.";
 
@@ -35,7 +48,7 @@ export const resumeSkills = [
   "Machine Learning",
 ];
 
-export const resumeExperience = [
+export const resumeExperience: ResumeExperienceItem[] = [
   {
     role: "Freelance Full-Stack Developer",
     company: "Freelance",
@@ -43,8 +56,14 @@ export const resumeExperience = [
     description:
       "Build custom web applications and software solutions with Django, Flask, React, and Next.js. Handle database design, API integrations, debugging, deployment, and long-term client support from launch through maintenance.",
     highlights: [
-      "Built and shipped mmaitland.dev (Next.js, Prisma, Auth.js) with validated contact intake, rate limiting, and admin OAuth - live in production.",
-      "Developed a Django auction platform with server-enforced bid rules, relational data modeling, and multi-user transaction flows.",
+      {
+        text: "Built and shipped mmaitland.dev (Next.js, Prisma, Auth.js) with validated contact intake, rate limiting, and admin OAuth.",
+        href: "https://www.mmaitland.dev",
+      },
+      {
+        text: "StringFlux product page: transient-aware multiband granular delay/freeze plugin currently in active development.",
+        href: "https://www.mmaitland.dev/stringflux",
+      },
     ],
   },
   {
@@ -54,8 +73,13 @@ export const resumeExperience = [
     description:
       "Deliver technical support for Full Swing simulator software and hardware, resolving installation, calibration, licensing, display, networking, and performance issues across commercial and residential environments.",
     highlights: [
-      "Standardized multi-layer triage workflows across calibration, licensing, display, networking, and OS subsystems - documented in a public case study.",
-      "Reduced repeat incidents on recurring failure classes by converting ad-hoc fixes into reproducible diagnostic playbooks.",
+      {
+        text: "Standardized multi-layer triage workflows across calibration, licensing, display, networking, and OS subsystems (documented publicly).",
+        href: "/projects/full-swing-tech-support",
+      },
+      {
+        text: "Reduced repeat incidents on recurring failure classes by converting ad-hoc fixes into reproducible diagnostic playbooks.",
+      },
     ],
   },
 ];


### PR DESCRIPTION
Convert resume highlights into linkable items and render them on both About and Resume pages so readers can quickly verify key claims.