### PR TITLE
fix(projects): render local SVG previews in project cards

### DIFF
--- a/src/components/sections/project-card.tsx
+++ b/src/components/sections/project-card.tsx
@@ -75,6 +75,7 @@ export function ProjectCard({ project, index, compact }: ProjectCardProps) {
             src={project.image}
             alt={`${project.title} preview`}
             fill
+            unoptimized={project.image.toLowerCase().endsWith(".svg")}
             className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />


### PR DESCRIPTION
Disable optimization for SVG card images so local public SVG assets render consistently instead of falling back to place-holder images.