### PR TITLE
feat(homepage): tighten hero and proof-strip around verifiable signals

### DIFF
--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -34,11 +34,13 @@ export function Hero() {
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
-          className="mt-6 mx-auto max-w-2xl text-lg leading-relaxed text-[rgba(194,203,220,0.82)] sm:text-xl"
+          className="mt-6 mx-auto max-w-3xl text-lg leading-relaxed text-[rgba(194,203,220,0.82)] sm:text-xl"
         >
-          I work full-time at Auxillium, supporting Full Swing GOLF software
-          and simulator systems. Outside of that, I build web and audio
-          software and produce original music as NEUROCHEMICAL ENTROPY.
+          I support Full Swing simulator software in live customer environments
+          at Auxillium, then apply the same failure-mode and tradeoff discipline
+          to building web systems in Next.js and TypeScript. This site documents
+          the work directly: hardened contact/admin flows, reproducible
+          troubleshooting patterns, and ongoing StringFlux DSP development.
         </motion.p>
 
         <motion.div

--- a/src/components/sections/proof-strip.tsx
+++ b/src/components/sections/proof-strip.tsx
@@ -2,25 +2,25 @@ import Link from "next/link";
 
 const proofItems = [
   {
-    title: "Technical support in production environments",
+    title: "Production simulator support under real constraints",
     detail:
-      "Full-time support at Auxillium for Full Swing GOLF software and simulator systems (2024\u2013present).",
+      "Full-time incident triage at Auxillium for Full Swing GOLF software and simulator systems (2024-present).",
     href: "/projects/full-swing-tech-support",
   },
   {
-    title: "Live site with operational safeguards",
+    title: "Web delivery with auth and abuse controls",
     detail:
-      "Production Next.js site with admin auth, validated contact intake, and abuse controls.",
-    href: "/projects",
+      "Live Next.js stack with admin OAuth, server-side validation, and contact intake protections.",
+    href: "/blog/contact-pipeline-decision-record",
   },
   {
-    title: "Audio software under active development",
+    title: "StringFlux DSP development",
     detail:
-      "StringFlux JUCE/C++ plugin with multiband routing and transient-driven grain scheduling.",
-    href: "/stringflux",
+      "JUCE/C++ plugin work: multiband routing, transient-driven grain scheduling, and safe oversampling transitions.",
+    href: "/projects/stringflux",
   },
   {
-    title: "Core stack",
+    title: "Core stack in active use",
     detail: "Next.js, TypeScript, Python, C++, PostgreSQL.",
   },
 ];


### PR DESCRIPTION
Reframe the above-the-fold copy to lead with production support context, concrete web-system evidence, and direct project proof links so reviewer trust is established faster.