### PR TITLE
feat(projects): add portfolio-site case study and proof artifact

### DIFF
--- a/public/images/projects/portfolio-delivery-artifact.svg
+++ b/public/images/projects/portfolio-delivery-artifact.svg
@@ -1,0 +1,55 @@
+﻿<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Portfolio delivery architecture artifact">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b1020"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect x="48" y="48" width="1104" height="579" rx="18" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+
+  <text x="84" y="110" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="34" font-weight="700">
+    Portfolio Delivery Flow (Webproject)
+  </text>
+  <text x="84" y="146" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="20">
+    Typed content, protected admin routes, contact intake safeguards, and CI-backed route checks.
+  </text>
+
+  <rect x="84" y="192" width="190" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="179" y="236" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Public pages</text>
+
+  <rect x="320" y="192" width="220" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="430" y="236" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Server actions</text>
+
+  <rect x="586" y="192" width="220" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="696" y="236" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Abuse controls</text>
+
+  <rect x="852" y="192" width="264" height="72" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="984" y="236" text-anchor="middle" fill="#cbd5e1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">Resend + Admin inbox</text>
+
+  <line x1="274" y1="228" x2="320" y2="228" stroke="url(#accent)" stroke-width="4"/>
+  <line x1="540" y1="228" x2="586" y2="228" stroke="url(#accent)" stroke-width="4"/>
+  <line x1="806" y1="228" x2="852" y2="228" stroke="url(#accent)" stroke-width="4"/>
+
+  <rect x="84" y="314" width="500" height="250" rx="14" fill="#111827" stroke="#334155"/>
+  <text x="108" y="350" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22" font-weight="600">Operational safeguards</text>
+  <text x="108" y="385" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Server-side schema validation before side effects</text>
+  <text x="108" y="417" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Honeypot + Upstash sliding-window limit</text>
+  <text x="108" y="449" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Auth.js protected admin routes</text>
+  <text x="108" y="481" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Prisma persistence after successful delivery path</text>
+  <text x="108" y="513" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Playwright smoke checks on trust-critical routes</text>
+
+  <rect x="620" y="314" width="496" height="250" rx="14" fill="#111827" stroke="#334155"/>
+  <text x="644" y="350" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22" font-weight="600">Engineering tradeoffs</text>
+  <text x="644" y="385" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Managed services over custom infra for reliability</text>
+  <text x="644" y="417" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Delivery-first contact flow, inbox as best-effort mirror</text>
+  <text x="644" y="449" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Typed content/data model to reduce silent regressions</text>
+  <text x="644" y="481" fill="#94a3b8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17">• Small-PR release cadence with CI gate</text>
+
+  <rect x="84" y="585" width="1032" height="8" rx="4" fill="url(#accent)"/>
+</svg>

--- a/src/app/projects/portfolio-site/page.tsx
+++ b/src/app/projects/portfolio-site/page.tsx
@@ -1,0 +1,174 @@
+﻿import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, CheckCircle2, FileCode2, ShieldCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+const PORTFOLIO_ARTIFACT_SRC = "/images/projects/portfolio-delivery-artifact.svg";
+
+export const metadata: Metadata = {
+  title: "Portfolio Website Case Study",
+  description:
+    "How this Next.js portfolio is delivered with typed content, protected admin routes, and abuse-resistant contact handling under practical constraints.",
+};
+
+const safeguards = [
+  "Server-side zod validation for contact and waitlist payloads before side effects",
+  "Honeypot plus Upstash sliding-window limiting on inbound actions",
+  "Auth.js GitHub OAuth gate for admin routes and inbox views",
+  "Prisma-backed persistence for contact/waitlist records",
+  "Playwright smoke coverage on trust-critical routes",
+];
+
+const tradeoffs = [
+  {
+    title: "Managed services over custom infrastructure",
+    detail:
+      "Used Resend, Upstash, and Neon-backed Prisma integration to reduce ops burden and improve reliability during solo iteration.",
+  },
+  {
+    title: "Delivery first, then persistence",
+    detail:
+      "Contact action treats email delivery as the primary success path, with inbox persistence as best-effort to avoid silent form success when mail is misconfigured.",
+  },
+  {
+    title: "Small-PR release discipline",
+    detail:
+      "Adopted merge-gated incremental updates to keep trust paths reviewable and prevent large, risky polish batches.",
+  },
+];
+
+const evidenceLinks = [
+  {
+    label: "Contact pipeline decision record",
+    href: "/blog/contact-pipeline-decision-record",
+  },
+  {
+    label: "Repository (webproject)",
+    href: "https://github.com/mmaitland300/webproject",
+  },
+  {
+    label: "Playwright route smoke spec",
+    href: "https://github.com/mmaitland300/webproject/blob/master/e2e/routes.spec.ts",
+  },
+];
+
+export default function PortfolioSiteCaseStudyPage() {
+  return (
+    <div className="py-24">
+      <div className="mx-auto max-w-4xl px-6">
+        <Link
+          href="/projects"
+          className="mb-8 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft size={14} /> Back to projects
+        </Link>
+
+        <header className="mb-12">
+          <div className="mb-4 flex flex-wrap gap-2">
+            <Badge variant="secondary">Next.js</Badge>
+            <Badge variant="secondary">Auth.js</Badge>
+            <Badge variant="secondary">Prisma</Badge>
+            <Badge variant="secondary">Operational Safeguards</Badge>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Portfolio Website: delivery and trust-path case study
+          </h1>
+          <p className="mt-4 max-w-3xl text-muted-foreground">
+            This page documents the engineering choices behind mmaitland.dev:
+            how contact intake, admin access, and content delivery are structured
+            to stay reliable under practical constraints rather than optimistic
+            assumptions.
+          </p>
+        </header>
+
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <div className="mb-3 flex items-center gap-2">
+            <FileCode2 className="h-5 w-5 text-cyan-400" />
+            <h2 className="text-xl font-semibold">Architecture artifact</h2>
+          </div>
+          <figure className="overflow-hidden rounded-lg border border-border bg-muted/20">
+            <div className="relative aspect-[1200/675] w-full">
+              <Image
+                src={PORTFOLIO_ARTIFACT_SRC}
+                alt="Portfolio delivery flow showing public routes, server actions, abuse controls, and admin inbox path"
+                fill
+                unoptimized
+                className="object-contain object-center p-2 sm:p-4"
+                sizes="(max-width: 768px) 100vw, 896px"
+                priority
+              />
+            </div>
+            <figcaption className="border-t border-border bg-card/50 px-4 py-3 text-center text-xs leading-relaxed text-muted-foreground">
+              Delivery artifact used to keep reliability assumptions explicit:
+              input validation, abuse controls, authenticated admin access, and
+              route-level regression checks.
+            </figcaption>
+          </figure>
+        </section>
+
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <div className="mb-3 flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-purple-400" />
+            <h2 className="text-xl font-semibold">Operational safeguards</h2>
+          </div>
+          <ul className="space-y-2">
+            {safeguards.map((item) => (
+              <li
+                key={item}
+                className="rounded-lg border border-border bg-card/30 px-4 py-3 text-sm text-muted-foreground"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <h2 className="mb-3 text-xl font-semibold">Tradeoffs and rationale</h2>
+          <div className="space-y-4">
+            {tradeoffs.map((item) => (
+              <div key={item.title}>
+                <h3 className="text-sm font-medium text-foreground">{item.title}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <h2 className="mb-3 text-xl font-semibold">Evidence links</h2>
+          <div className="space-y-2">
+            {evidenceLinks.map((item) => {
+              const isExternal = item.href.startsWith("http");
+              return (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  target={isExternal ? "_blank" : undefined}
+                  rel={isExternal ? "noopener noreferrer" : undefined}
+                  className="block rounded-lg border border-border bg-card/30 px-4 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </a>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-border bg-card/40 p-6">
+          <div className="mb-3 flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-emerald-400" />
+            <h2 className="text-xl font-semibold">Outcome signal</h2>
+          </div>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Operational proxy:</span>{" "}
+            a production portfolio that can reliably receive contact, protect
+            admin-only surfaces, and expose engineering reasoning through linked
+            decision records and case-study artifacts.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -1,4 +1,4 @@
-export type ProjectCategory = "featured" | "experiment";
+﻿export type ProjectCategory = "featured" | "experiment";
 
 export interface Project {
   slug: string;
@@ -85,6 +85,8 @@ export const projects: Project[] = [
       "MDX",
     ],
     github: "https://github.com/mmaitland300/webproject",
+    image: "/images/projects/portfolio-delivery-artifact.svg",
+    caseStudy: "/projects/portfolio-site",
     category: "featured",
   },
   {
@@ -210,3 +212,4 @@ export function getHomepageFeaturedProjects(): Project[] {
 export function getExperiments() {
   return projects.filter((p) => p.category === "experiment");
 }
+


### PR DESCRIPTION
Add a dedicated /projects/portfolio-site case study with delivery-flow artifact, wire project card image/caseStudy in projects data, and align evidence with existing blog/repo links.