### PR TITLE
feat(env): centralize typed env parsing and feature validation

### DIFF
--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -5,6 +5,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { headers } from "next/headers";
 import { contactSchema } from "./contact.contract";
+import { getContactDeliveryEnv, hasUpstashRedisEnv, parseAppEnv } from "@/lib/env";
 
 export type ContactState = {
   success: boolean;
@@ -15,10 +16,7 @@ export type ContactState = {
 let ratelimit: Ratelimit | null = null;
 function getRatelimit() {
   if (ratelimit) return ratelimit;
-  if (
-    process.env.UPSTASH_REDIS_REST_URL &&
-    process.env.UPSTASH_REDIS_REST_TOKEN
-  ) {
+  if (hasUpstashRedisEnv()) {
     ratelimit = new Ratelimit({
       redis: Redis.fromEnv(),
       limiter: Ratelimit.slidingWindow(3, "60 s"),
@@ -71,11 +69,8 @@ export async function submitContact(
   }
 
   // Send email via Resend (must succeed before optional DB persistence)
-  const resendKey = process.env.RESEND_API_KEY;
-  const fromEmail = process.env.CONTACT_FROM_EMAIL;
-  const toEmail = process.env.CONTACT_TO_EMAIL;
-
-  if (!resendKey || !fromEmail || !toEmail) {
+  const contactDeliveryEnv = getContactDeliveryEnv();
+  if (!contactDeliveryEnv) {
     console.error("Missing Resend env vars");
     return {
       success: false,
@@ -84,10 +79,10 @@ export async function submitContact(
   }
 
   try {
-    const resend = new Resend(resendKey);
+    const resend = new Resend(contactDeliveryEnv.RESEND_API_KEY);
     await resend.emails.send({
-      from: fromEmail,
-      to: toEmail,
+      from: contactDeliveryEnv.CONTACT_FROM_EMAIL,
+      to: contactDeliveryEnv.CONTACT_TO_EMAIL,
       replyTo: parsed.data.email,
       subject: `Portfolio Contact: ${parsed.data.name}`,
       text: [
@@ -109,7 +104,7 @@ export async function submitContact(
   // Persist only after email delivery succeeds (avoids orphan inbox rows on misconfig or send failure).
   // Reliability tradeoff: the UI success path is driven by email delivery; admin inbox persistence
   // is best-effort and may be missed if Prisma/DB persistence fails.
-  if (process.env.DATABASE_URL) {
+  if (parseAppEnv().DATABASE_URL) {
     try {
       const { prisma } = await import("@/lib/prisma");
       await prisma.contactSubmission.create({

--- a/src/actions/stringflux-waitlist.ts
+++ b/src/actions/stringflux-waitlist.ts
@@ -5,6 +5,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { headers } from "next/headers";
 import { isWaitlistConfigured } from "@/lib/feature-config";
+import { getResendSenderEnv, hasUpstashRedisEnv, parseAppEnv } from "@/lib/env";
 import {
   normalizeWaitlistEmail,
   waitlistSchema,
@@ -19,10 +20,7 @@ export type WaitlistState = {
 let ratelimit: Ratelimit | null = null;
 function getRatelimit() {
   if (ratelimit) return ratelimit;
-  if (
-    process.env.UPSTASH_REDIS_REST_URL &&
-    process.env.UPSTASH_REDIS_REST_TOKEN
-  ) {
+  if (hasUpstashRedisEnv()) {
     ratelimit = new Ratelimit({
       redis: Redis.fromEnv(),
       limiter: Ratelimit.slidingWindow(3, "60 s"),
@@ -99,17 +97,16 @@ export async function joinWaitlist(
   }
 
   // Email notifications are best-effort. The durable source of truth is DB persistence above.
-  const resendKey = process.env.RESEND_API_KEY;
-  const fromEmail = process.env.CONTACT_FROM_EMAIL;
-  const toEmail = process.env.CONTACT_TO_EMAIL;
-  if (resendKey && fromEmail) {
-    const resend = new Resend(resendKey);
+  const resendSenderEnv = getResendSenderEnv();
+  const contactToEmail = parseAppEnv().CONTACT_TO_EMAIL;
+  if (resendSenderEnv) {
+    const resend = new Resend(resendSenderEnv.RESEND_API_KEY);
 
-    if (toEmail) {
+    if (contactToEmail) {
       try {
         await resend.emails.send({
-          from: fromEmail,
-          to: toEmail,
+          from: resendSenderEnv.CONTACT_FROM_EMAIL,
+          to: contactToEmail,
           subject: `StringFlux Waitlist Signup: ${normalizedEmail}`,
           text: [
             `A new StringFlux waitlist signup was received.`,
@@ -133,7 +130,7 @@ export async function joinWaitlist(
 
     try {
       await resend.emails.send({
-        from: fromEmail,
+        from: resendSenderEnv.CONTACT_FROM_EMAIL,
         to: normalizedEmail,
         subject: "You're on the StringFlux waitlist",
         text: [

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { isAdminAuthConfigured } from "@/lib/feature-config";
 import { prisma } from "@/lib/prisma";
+import { getAdminGithubIds } from "@/lib/env";
 
 export async function isAdmin(): Promise<boolean> {
   if (!isAdminAuthConfigured()) return false;
@@ -9,9 +10,7 @@ export async function isAdmin(): Promise<boolean> {
   const session = await auth();
   if (!session?.user?.id) return false;
 
-  const adminIds = process.env.ADMIN_GITHUB_IDS?.split(",").map((s) =>
-    s.trim()
-  );
+  const adminIds = getAdminGithubIds();
   if (!adminIds?.length) return false;
 
   const account = await prisma.account.findFirst({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,21 +3,24 @@ import GitHub from "next-auth/providers/github";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
 import { isAdminAuthConfigured } from "@/lib/feature-config";
+import { getAdminAuthEnv } from "@/lib/env";
 
 const adminAuthConfigured = isAdminAuthConfigured();
+const adminAuthEnv = adminAuthConfigured ? getAdminAuthEnv() : null;
+const providers = adminAuthEnv
+  ? [
+      GitHub({
+        clientId: adminAuthEnv.AUTH_GITHUB_ID,
+        clientSecret: adminAuthEnv.AUTH_GITHUB_SECRET,
+      }),
+    ]
+  : [];
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...(adminAuthConfigured ? { adapter: PrismaAdapter(prisma) } : {}),
-  providers: adminAuthConfigured
-    ? [
-        GitHub({
-          clientId: process.env.AUTH_GITHUB_ID!,
-          clientSecret: process.env.AUTH_GITHUB_SECRET!,
-        }),
-      ]
-    : [],
+  providers,
   pages: {
     signIn: "/admin/login",
   },
-  secret: process.env.AUTH_SECRET ?? "admin-auth-disabled",
+  secret: adminAuthEnv?.AUTH_SECRET ?? "admin-auth-disabled",
 });

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,82 @@
+﻿import { describe, expect, it } from "vitest";
+import {
+  getAdminGithubIds,
+  getContactDeliveryEnv,
+  getResendSenderEnv,
+  hasUpstashRedisEnv,
+  isAdminAuthEnvConfigured,
+  isWaitlistEnvConfigured,
+} from "./env";
+
+describe("isWaitlistEnvConfigured", () => {
+  it("requires DATABASE_URL", () => {
+    expect(isWaitlistEnvConfigured({})).toBe(false);
+    expect(isWaitlistEnvConfigured({ DATABASE_URL: "postgres://db" })).toBe(true);
+  });
+});
+
+describe("isAdminAuthEnvConfigured", () => {
+  it("returns false when required fields are missing", () => {
+    expect(
+      isAdminAuthEnvConfigured({
+        DATABASE_URL: "postgres://db",
+        AUTH_SECRET: "secret",
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when all required fields are present", () => {
+    expect(
+      isAdminAuthEnvConfigured({
+        DATABASE_URL: "postgres://db",
+        AUTH_SECRET: "secret",
+        AUTH_GITHUB_ID: "id",
+        AUTH_GITHUB_SECRET: "secret",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("contact and resend env parsing", () => {
+  it("requires full contact delivery env", () => {
+    expect(
+      getContactDeliveryEnv({
+        RESEND_API_KEY: "re_123",
+        CONTACT_FROM_EMAIL: "contact@example.com",
+      })
+    ).toBeNull();
+  });
+
+  it("allows resend sender env without CONTACT_TO_EMAIL", () => {
+    expect(
+      getResendSenderEnv({
+        RESEND_API_KEY: "re_123",
+        CONTACT_FROM_EMAIL: "contact@example.com",
+      })
+    ).toEqual({
+      RESEND_API_KEY: "re_123",
+      CONTACT_FROM_EMAIL: "contact@example.com",
+    });
+  });
+});
+
+describe("misc env helpers", () => {
+  it("parses admin github ids", () => {
+    expect(getAdminGithubIds({ ADMIN_GITHUB_IDS: "123, 456 , ,789" })).toEqual([
+      "123",
+      "456",
+      "789",
+    ]);
+  });
+
+  it("detects upstash env presence", () => {
+    expect(hasUpstashRedisEnv({})).toBe(false);
+    expect(
+      hasUpstashRedisEnv({
+        UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+        UPSTASH_REDIS_REST_TOKEN: "token",
+      })
+    ).toBe(true);
+  });
+});
+

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,112 @@
+﻿import { z } from "zod";
+
+const optionalTrimmedString = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}, z.string().optional());
+
+const appEnvSchema = z.object({
+  DATABASE_URL: optionalTrimmedString,
+  DIRECT_URL: optionalTrimmedString,
+  AUTH_SECRET: optionalTrimmedString,
+  AUTH_GITHUB_ID: optionalTrimmedString,
+  AUTH_GITHUB_SECRET: optionalTrimmedString,
+  ADMIN_GITHUB_IDS: optionalTrimmedString,
+  RESEND_API_KEY: optionalTrimmedString,
+  CONTACT_FROM_EMAIL: optionalTrimmedString,
+  CONTACT_TO_EMAIL: optionalTrimmedString,
+  UPSTASH_REDIS_REST_URL: optionalTrimmedString,
+  UPSTASH_REDIS_REST_TOKEN: optionalTrimmedString,
+  NEXT_PUBLIC_SITE_URL: optionalTrimmedString,
+  NEXT_PUBLIC_CONTACT_EMAIL: optionalTrimmedString,
+  VERCEL_PROJECT_PRODUCTION_URL: optionalTrimmedString,
+  VERCEL_URL: optionalTrimmedString,
+});
+
+const adminAuthEnvSchema = z.object({
+  DATABASE_URL: z.string().min(1),
+  AUTH_SECRET: z.string().min(1),
+  AUTH_GITHUB_ID: z.string().min(1),
+  AUTH_GITHUB_SECRET: z.string().min(1),
+});
+
+const contactDeliveryEnvSchema = z.object({
+  RESEND_API_KEY: z.string().min(1),
+  CONTACT_FROM_EMAIL: z.string().email(),
+  CONTACT_TO_EMAIL: z.string().email(),
+});
+const resendSenderEnvSchema = z.object({
+  RESEND_API_KEY: z.string().min(1),
+  CONTACT_FROM_EMAIL: z.string().email(),
+});
+
+export type AppEnv = z.infer<typeof appEnvSchema>;
+export type AdminAuthEnv = z.infer<typeof adminAuthEnvSchema>;
+export type ContactDeliveryEnv = z.infer<typeof contactDeliveryEnvSchema>;
+export type ResendSenderEnv = z.infer<typeof resendSenderEnvSchema>;
+
+export function parseAppEnv(env: NodeJS.ProcessEnv = process.env): AppEnv {
+  return appEnvSchema.parse(env);
+}
+
+export function isWaitlistEnvConfigured(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const parsed = parseAppEnv(env);
+  return Boolean(parsed.DATABASE_URL);
+}
+
+export function isAdminAuthEnvConfigured(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const parsed = parseAppEnv(env);
+  return adminAuthEnvSchema.safeParse(parsed).success;
+}
+
+export function getAdminAuthEnv(
+  env: NodeJS.ProcessEnv = process.env
+): AdminAuthEnv {
+  const parsed = parseAppEnv(env);
+  return adminAuthEnvSchema.parse(parsed);
+}
+
+export function getContactDeliveryEnv(
+  env: NodeJS.ProcessEnv = process.env
+): ContactDeliveryEnv | null {
+  const parsed = parseAppEnv(env);
+  const result = contactDeliveryEnvSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+export function getResendSenderEnv(
+  env: NodeJS.ProcessEnv = process.env
+): ResendSenderEnv | null {
+  const parsed = parseAppEnv(env);
+  const result = resendSenderEnvSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+export function hasUpstashRedisEnv(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const parsed = parseAppEnv(env);
+  return Boolean(parsed.UPSTASH_REDIS_REST_URL && parsed.UPSTASH_REDIS_REST_TOKEN);
+}
+
+export function getAdminGithubIds(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const parsed = parseAppEnv(env);
+  if (!parsed.ADMIN_GITHUB_IDS) {
+    return [];
+  }
+
+  return parsed.ADMIN_GITHUB_IDS.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+

--- a/src/lib/feature-config.ts
+++ b/src/lib/feature-config.ts
@@ -1,16 +1,13 @@
+import { isAdminAuthEnvConfigured, isWaitlistEnvConfigured } from "@/lib/env";
+
 export function isWaitlistConfigured(
   env: NodeJS.ProcessEnv = process.env
 ): boolean {
-  return Boolean(env.DATABASE_URL);
+  return isWaitlistEnvConfigured(env);
 }
 
 export function isAdminAuthConfigured(
   env: NodeJS.ProcessEnv = process.env
 ): boolean {
-  return Boolean(
-    env.DATABASE_URL &&
-      env.AUTH_SECRET &&
-      env.AUTH_GITHUB_ID &&
-      env.AUTH_GITHUB_SECRET
-  );
+  return isAdminAuthEnvConfigured(env);
 }

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -1,3 +1,5 @@
+import { parseAppEnv } from "@/lib/env";
+
 /**
  * Public-facing contact email shown on the site (footer, about, contact page, resume).
  * Override with NEXT_PUBLIC_CONTACT_EMAIL in Vercel env vars if this ever changes.
@@ -5,9 +7,9 @@
 const FALLBACK_PUBLIC_EMAIL = "contact@mmaitland.dev";
 
 export function getPublicContactEmail(): string {
-  const v = process.env.NEXT_PUBLIC_CONTACT_EMAIL;
-  if (typeof v === "string" && v.trim().length > 0) {
-    return v.trim();
+  const publicContactEmail = parseAppEnv().NEXT_PUBLIC_CONTACT_EMAIL;
+  if (publicContactEmail) {
+    return publicContactEmail;
   }
   return FALLBACK_PUBLIC_EMAIL;
 }

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,3 +1,5 @@
+import { parseAppEnv } from "@/lib/env";
+
 const LOCAL_SITE_URL = "http://localhost:3000";
 
 function normalizeUrl(value: string) {
@@ -7,15 +9,15 @@ function normalizeUrl(value: string) {
 }
 
 export function getSiteUrl() {
-  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  const env = parseAppEnv();
+  const configuredUrl = env.NEXT_PUBLIC_SITE_URL;
   if (configuredUrl) {
     return normalizeUrl(configuredUrl);
   }
 
-  const deploymentUrl =
-    process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
+  const deploymentUrl = env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL;
   if (deploymentUrl) {
-    return normalizeUrl(deploymentUrl.trim());
+    return normalizeUrl(deploymentUrl);
   }
 
   return LOCAL_SITE_URL;


### PR DESCRIPTION
Added a zod-backed env helper module with tests and route feature/config call sites through it so env policy is defined in one place instead of ad hoc process.env access.