### PR TITLE
refactor(ui): reuse shared highlight link renderer

### DIFF
--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -7,8 +7,8 @@ import {
   resumeExperience,
   resumeSkills,
   resumeSummary,
-  type ResumeHighlight,
 } from "@/content/resume";
+import { HighlightText } from "@/components/ui/highlight-text";
 import { getPublicContactEmail } from "@/lib/site-contact";
 
 export const metadata: Metadata = {
@@ -16,25 +16,6 @@ export const metadata: Metadata = {
   description:
     "Resume for Matt Maitland covering full-stack development and technical support experience.",
 };
-
-function HighlightText({ highlight }: { highlight: ResumeHighlight }) {
-  if (!highlight.href) {
-    return <>{highlight.text}</>;
-  }
-
-  const isExternal = /^https?:\/\//.test(highlight.href);
-
-  return (
-    <a
-      href={highlight.href}
-      target={isExternal ? "_blank" : undefined}
-      rel={isExternal ? "noopener noreferrer" : undefined}
-      className="underline decoration-purple-500/50 underline-offset-4 transition-colors hover:text-foreground"
-    >
-      {highlight.text}
-    </a>
-  );
-}
 
 export default function ResumePage() {
   const publicEmail = getPublicContactEmail();

--- a/src/components/sections/about-content.tsx
+++ b/src/components/sections/about-content.tsx
@@ -18,8 +18,8 @@ import {
   resumeExperience as experience,
   resumeEducation as education,
   resumeCertifications as certifications,
-  type ResumeHighlight,
 } from "@/content/resume";
+import { HighlightText } from "@/components/ui/highlight-text";
 
 type AboutContentProps = {
   publicEmail: string;
@@ -31,25 +31,6 @@ const fadeUp = {
   viewport: { once: true as const },
   transition: { duration: 0.5 },
 };
-
-function HighlightText({ highlight }: { highlight: ResumeHighlight }) {
-  if (!highlight.href) {
-    return <>{highlight.text}</>;
-  }
-
-  const isExternal = /^https?:\/\//.test(highlight.href);
-
-  return (
-    <a
-      href={highlight.href}
-      target={isExternal ? "_blank" : undefined}
-      rel={isExternal ? "noopener noreferrer" : undefined}
-      className="underline decoration-purple-500/50 underline-offset-4 transition-colors hover:text-foreground"
-    >
-      {highlight.text}
-    </a>
-  );
-}
 
 export function AboutContent({ publicEmail }: AboutContentProps) {
   return (

--- a/src/components/ui/highlight-text.tsx
+++ b/src/components/ui/highlight-text.tsx
@@ -1,0 +1,25 @@
+﻿import type { ResumeHighlight } from "@/content/resume";
+
+interface HighlightTextProps {
+  highlight: ResumeHighlight;
+}
+
+export function HighlightText({ highlight }: HighlightTextProps) {
+  if (!highlight.href) {
+    return <>{highlight.text}</>;
+  }
+
+  const isExternal = /^https?:\/\//.test(highlight.href);
+
+  return (
+    <a
+      href={highlight.href}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
+      className="underline decoration-purple-500/50 underline-offset-4 transition-colors hover:text-foreground"
+    >
+      {highlight.text}
+    </a>
+  );
+}
+


### PR DESCRIPTION
Extract HighlightText into a shared UI component and consume it from About and Resume so link behavior and styling stay consistent across evidence sections.