### PR TITLE
Wave 1A: Project voice reset and comment cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint . --max-warnings 0",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "postinstall": "prisma generate"

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -53,7 +53,6 @@ export async function submitContact(
     };
   }
 
-  // Rate limiting
   const rl = getRatelimit();
   if (rl) {
     const headerStore = await headers();
@@ -68,7 +67,6 @@ export async function submitContact(
     }
   }
 
-  // Send email via Resend (must succeed before optional DB persistence)
   const contactDeliveryEnv = getContactDeliveryEnv();
   if (!contactDeliveryEnv) {
     console.error("Missing Resend env vars");
@@ -101,9 +99,7 @@ export async function submitContact(
     };
   }
 
-  // Persist only after email delivery succeeds (avoids orphan inbox rows on misconfig or send failure).
-  // Reliability tradeoff: the UI success path is driven by email delivery; admin inbox persistence
-  // is best-effort and may be missed if Prisma/DB persistence fails.
+  // Best-effort: email delivery is the success gate
   if (parseAppEnv().DATABASE_URL) {
     try {
       const { prisma } = await import("@/lib/prisma");
@@ -115,10 +111,7 @@ export async function submitContact(
         },
       });
     } catch (err) {
-      console.error(
-        "Admin inbox persistence failed after successful email delivery (best-effort path):",
-        err
-      );
+      console.error("Admin inbox persistence failed (best-effort):", err);
     }
   }
 

--- a/src/actions/stringflux-waitlist.ts
+++ b/src/actions/stringflux-waitlist.ts
@@ -61,7 +61,6 @@ export async function joinWaitlist(
     };
   }
 
-  // Rate limiting
   const rl = getRatelimit();
   if (rl) {
     const headerStore = await headers();
@@ -96,7 +95,7 @@ export async function joinWaitlist(
     };
   }
 
-  // Email notifications are best-effort. The durable source of truth is DB persistence above.
+  // Best-effort notifications
   const resendSenderEnv = getResendSenderEnv();
   const contactToEmail = parseAppEnv().CONTACT_TO_EMAIL;
   if (resendSenderEnv) {

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,25 @@
+export default function BlogLoading() {
+  return (
+    <div className="py-32">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mb-12 space-y-3">
+          <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+          <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-[24rem] max-w-full animate-pulse rounded bg-muted" />
+        </div>
+        <div className="space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-border bg-card/50 p-5 space-y-3"
+            >
+              <div className="h-5 w-2/3 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-full animate-pulse rounded bg-muted" />
+              <div className="h-3 w-5/6 animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function AppError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center px-6">
+      <div className="w-full max-w-lg rounded-xl border border-border bg-card/60 p-6 text-center">
+        <div className="mx-auto mb-4 inline-flex rounded-full bg-muted p-3 text-amber-400">
+          <AlertTriangle className="h-5 w-5" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something broke</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          An unexpected error occurred. Try again, and if it keeps happening,
+          please refresh the page.
+        </p>
+        <button
+          onClick={() => unstable_retry()}
+          className="mt-5 inline-flex items-center gap-2 rounded-md border border-border bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function GlobalError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en" className="dark h-full antialiased">
+      <body className="min-h-full bg-background text-foreground">
+        <div className="min-h-screen flex items-center justify-center px-6">
+          <div className="w-full max-w-lg rounded-xl border border-border bg-card/60 p-6 text-center">
+            <div className="mx-auto mb-4 inline-flex rounded-full bg-muted p-3 text-amber-400">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+            <h1 className="text-xl font-semibold">Application error</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              A root-level error occurred. Retry the view, or reload if needed.
+            </p>
+            <button
+              onClick={() => unstable_retry()}
+              className="mt-5 inline-flex items-center gap-2 rounded-md border border-border bg-muted px-4 py-2 text-sm font-medium transition-colors hover:bg-muted/70"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,14 @@
+export default function RootLoading() {
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center px-6">
+      <div className="w-full max-w-xl rounded-xl border border-border bg-card/50 p-6">
+        <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+        <div className="mt-4 space-y-2">
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-[92%] animate-pulse rounded bg-muted" />
+          <div className="h-3 w-[86%] animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  description: "The requested page could not be found.",
+};
 
 export default function NotFound() {
   return (

--- a/src/app/projects/loading.tsx
+++ b/src/app/projects/loading.tsx
@@ -1,0 +1,26 @@
+export default function ProjectsLoading() {
+  return (
+    <div className="py-32">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mb-12 space-y-3">
+          <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          <div className="h-8 w-72 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-[26rem] max-w-full animate-pulse rounded bg-muted" />
+        </div>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-border bg-card/50 p-5 space-y-3"
+            >
+              <div className="h-40 w-full animate-pulse rounded-md bg-muted" />
+              <div className="h-5 w-2/3 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-full animate-pulse rounded bg-muted" />
+              <div className="h-3 w-5/6 animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/case-studies/ml-eval-workflow-diagram.tsx
+++ b/src/components/case-studies/ml-eval-workflow-diagram.tsx
@@ -1,9 +1,61 @@
-/** Train/eval/review loop for ML case studies (illustrative, not a full pipeline diagram). */
+"use client";
+
+import { useState } from "react";
+
+const workflowSteps = [
+  {
+    x: 12,
+    w: 88,
+    label: "Data",
+    detail:
+      "Capture raw images and label sources. This is where class imbalance and label quality risks start.",
+  },
+  {
+    x: 118,
+    w: 92,
+    label: "Clean / split",
+    detail:
+      "Apply deterministic cleanup and stratified train/validation splits so runs remain directly comparable.",
+  },
+  {
+    x: 226,
+    w: 72,
+    label: "Train",
+    detail:
+      "Run training with fixed settings and logged changes. Avoid changing multiple variables between runs.",
+  },
+  {
+    x: 314,
+    w: 88,
+    label: "Metrics",
+    detail:
+      "Track per-class precision/recall and loss trends, not just aggregate accuracy.",
+  },
+  {
+    x: 418,
+    w: 100,
+    label: "Confusion review",
+    detail:
+      "Inspect confusion matrix and wrong predictions to identify exact failure modes before architecture changes.",
+  },
+  {
+    x: 534,
+    w: 94,
+    label: "Next change",
+    detail:
+      "Choose one controlled update (data, augmentation, or model tweak), then repeat the same loop.",
+  },
+] as const;
+
+/** Interactive train/eval/review loop for ML case studies. */
 export function MlEvalWorkflowDiagram() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeStep = workflowSteps[activeIndex];
+
   return (
     <figure className="my-6 overflow-x-auto rounded-lg border border-border bg-muted/30 p-4">
       <figcaption className="mb-3 text-center text-xs font-medium text-muted-foreground">
-        Figure: reproducible evaluation loop (same splits and artifacts every run)
+        Interactive workflow: inspect each stage of the reproducible evaluation loop
       </figcaption>
       <svg
         viewBox="0 0 640 100"
@@ -23,14 +75,7 @@ export function MlEvalWorkflowDiagram() {
             <path d="M0,0 L8,4 L0,8 Z" className="fill-muted-foreground" />
           </marker>
         </defs>
-        {[
-          { x: 12, w: 88, label: "Data" },
-          { x: 118, w: 92, label: "Clean / split" },
-          { x: 226, w: 72, label: "Train" },
-          { x: 314, w: 88, label: "Metrics" },
-          { x: 418, w: 100, label: "Confusion review" },
-          { x: 534, w: 94, label: "Next change" },
-        ].map((box, i, arr) => (
+        {workflowSteps.map((box, i, arr) => (
           <g key={box.label}>
             <rect
               x={box.x}
@@ -38,8 +83,12 @@ export function MlEvalWorkflowDiagram() {
               width={box.w}
               height="44"
               rx="6"
-              className="fill-card stroke-border"
-              strokeWidth="1"
+              className={
+                i === activeIndex
+                  ? "fill-card stroke-[rgba(136,212,255,0.95)]"
+                  : "fill-card stroke-border"
+              }
+              strokeWidth={i === activeIndex ? "1.5" : "1"}
             />
             <text
               x={box.x + box.w / 2}
@@ -63,6 +112,26 @@ export function MlEvalWorkflowDiagram() {
           </g>
         ))}
       </svg>
+      <div className="mt-4 rounded-md border border-border bg-card/60 p-3 text-sm">
+        <p className="font-medium text-foreground">{activeStep.label}</p>
+        <p className="mt-1 text-muted-foreground">{activeStep.detail}</p>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {workflowSteps.map((step, i) => (
+          <button
+            key={step.label}
+            type="button"
+            onClick={() => setActiveIndex(i)}
+            className={
+              i === activeIndex
+                ? "rounded-md border border-purple-500/30 bg-purple-500/20 px-2.5 py-1 text-xs text-purple-300"
+                : "rounded-md border border-border bg-card/60 px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground"
+            }
+          >
+            {step.label}
+          </button>
+        ))}
+      </div>
     </figure>
   );
 }

--- a/src/components/sections/project-card.tsx
+++ b/src/components/sections/project-card.tsx
@@ -14,16 +14,6 @@ interface ProjectCardProps {
   compact?: boolean;
 }
 
-const outcomeLabels: Record<
-  NonNullable<Project["outcomeType"]>,
-  string
-> = {
-  metric: "Outcome (Metric)",
-  proxy: "Outcome (Operational Proxy)",
-  technical: "Outcome (Technical)",
-  qualitative: "Outcome (Qualitative)",
-};
-
 export function ProjectCard({ project, index, compact }: ProjectCardProps) {
   const [iframeActive, setIframeActive] = useState(false);
   const internalDemoHref = project.demo?.startsWith("/") ? project.demo : null;
@@ -136,9 +126,7 @@ export function ProjectCard({ project, index, compact }: ProjectCardProps) {
             {project.outcome && (
               <div>
                 <span className="font-medium text-foreground/80">
-                  {project.outcomeType
-                    ? `${outcomeLabels[project.outcomeType]}: `
-                    : "Outcome: "}
+                  Outcome:{" "}
                 </span>
                 <span className="text-muted-foreground">{project.outcome}</span>
               </div>

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -10,7 +10,6 @@ export interface Project {
   tradeoff?: string;
   role?: string;
   outcome?: string;
-  outcomeType?: "metric" | "proxy" | "technical" | "qualitative";
   image?: string;
   tags: string[];
   github?: string;
@@ -20,10 +19,6 @@ export interface Project {
   category: ProjectCategory;
 }
 
-/**
- * Homepage keeps one card per major signal area:
- * DSP build, systems troubleshooting, and workflow-heavy utility tooling.
- */
 const HOMEPAGE_FEATURED_SLUGS = [
   "stringflux",
   "sample-organizer",
@@ -35,18 +30,15 @@ export const projects: Project[] = [
     slug: "stringflux",
     title: "StringFlux",
     description:
-      "A transient-aware, multiband granular delay and freeze plugin for guitar and other stringed instruments.",
+      "A multiband granular delay and freeze plugin I'm building for guitar. It listens for transients and uses them to drive grain scheduling, so the texture responds to how you actually play instead of running on a fixed clock.",
     problem:
-      "Generic granular processors often miss instrument-specific transient behavior, which limits expressive control for stringed-instrument performance.",
+      "Most granular processors treat every input the same. For stringed instruments, that means pick attacks get smeared and the effect feels disconnected from the performance.",
     constraints:
-      "Real-time DSP constraints required safe oversampling transitions, predictable latency behavior, and stable processing under varying host settings.",
+      "Everything runs in the audio callback, so oversampling changes and grain scheduling have to be real-time safe. I can't rebuild state mid-buffer without risking glitches.",
     tradeoff:
-      "Prioritized deterministic scheduling and engine stability over feature breadth so instrument response remains controllable while the system is still evolving.",
-    role:
-      "Solo developer responsible for product direction, DSP architecture, and implementation.",
+      "I've kept the feature set narrow on purpose — getting the engine stable and the transient response right matters more than adding controls nobody can trust yet.",
     outcome:
-      "In progress. Current implementation includes 3-band crossover routing, transient and density-driven grain scheduling, history/freeze capture, feedback-bus processing, and safe 1x/2x/4x oversampling transitions.",
-    outcomeType: "technical",
+      "Still in progress. The current build has 3-band crossover routing, transient-driven grain scheduling, history/freeze capture, and safe 1x/2x/4x oversampling transitions.",
     tags: [
       "Audio Plugin",
       "DSP",
@@ -64,17 +56,15 @@ export const projects: Project[] = [
     slug: "portfolio-site",
     title: "Portfolio Website",
     description:
-      "Production Next.js portfolio with MDX blogging, a protected admin inbox, and an abuse-resistant contact flow. Built with typed content/data structures and deployment-ready environment management.",
+      "This site. Next.js 16 with MDX blogging, a contact form that sends email through Resend and falls back gracefully when the database is down, and a GitHub OAuth admin inbox for managing submissions.",
     problem:
-      "Needed a credible public portfolio that could showcase work, accept contact reliably, and support iterative updates without breaking production.",
+      "I needed somewhere to put my work that wasn't just a GitHub profile. It had to accept contact without getting spammed, and I wanted to be able to iterate on it without worrying about breaking production.",
     constraints:
-      "Needed secure admin access, abuse-resistant contact handling, and deploy-safe content workflows without introducing heavy operational overhead.",
+      "Solo project, so operational overhead had to stay low. No dedicated backend — managed services (Resend for email, Upstash for rate limiting, Neon for Postgres) handle the heavy parts.",
     tradeoff:
-      "Chose server actions plus managed services (Resend, Upstash, Neon) over custom infrastructure to improve reliability and iteration speed.",
-    role: "Solo developer, system design, UI implementation, data modeling, auth, deployment, and documentation.",
+      "Server Actions over API routes, managed services over self-hosted infra. More vendor lock-in, but significantly less to maintain and debug alone.",
     outcome:
-      "Shipped a live site with server-side validation, honeypot plus Redis rate limiting, GitHub OAuth admin gating, and draft-post protection.",
-    outcomeType: "technical",
+      "Live at mmaitland.dev with honeypot + Redis rate limiting on contact, GitHub OAuth admin gating, and MDX blog with draft protection.",
     tags: [
       "Next.js",
       "TypeScript",
@@ -90,59 +80,19 @@ export const projects: Project[] = [
     category: "featured",
   },
   {
-    slug: "snake-detector",
-    title: "Snake Detector (CNN)",
-    description:
-      "CV experiment focused on dataset hygiene and evaluation discipline: stratified splits, augmentation policy, and confusion-matrix-driven error review before architecture changes.",
-    problem:
-      "Snake photo classification fails quietly when class imbalance, label noise, and inconsistent image quality are ignored; naive training runs look fine on paper but generalize poorly.",
-    constraints:
-      "Limited and noisy source data increased overfitting risk; without explicit val discipline, mistakes read as model issues instead of data issues.",
-    tradeoff:
-      "Invested in reproducible splits, logging, and error analysis before expanding model capacity so tuning decisions stay tied to measurable failure modes.",
-    role: "ML engineer, data curation, preprocessing strategy, model and training setup, and error analysis.",
-    outcome:
-      "End-to-end pipeline where every training run is comparable (same splits, metrics, artifacts) and poor classes surface in review instead of hiding in aggregate accuracy.",
-    outcomeType: "technical",
-    tags: ["Python", "Machine Learning", "CNN", "Computer Vision"],
-    github: "https://github.com/mmaitland300/Snake-detector",
-    caseStudy: "/projects/snake-detector",
-    category: "experiment",
-  },
-  {
-    slug: "auction-house",
-    title: "Auction House",
-    description:
-      "Full-stack Django auction platform with account auth, listing lifecycle management, bid validation rules, watchlists, and category browsing.",
-    problem:
-      "Needed to implement transactional auction behavior with reliable server-side rules for bidding and ownership in a multi-user workflow.",
-    constraints:
-      "Correctness depended on enforcing bid and listing rules server-side across concurrent user actions and persistent relational data.",
-    tradeoff:
-      "Used server-rendered Django patterns and strict model-level rules to prioritize correctness and maintainability over richer client-side interactivity.",
-    role: "Full-stack developer, data modeling, auth/session flows, bid logic, template UI implementation, and route-level behavior.",
-    outcome:
-      "Built a complete web app covering core auction flows (create, list, bid, watch, manage) with server-enforced business rules and persistent relational data.",
-    outcomeType: "technical",
-    tags: ["Django", "Python", "PostgreSQL", "HTML/CSS"],
-    github: "https://github.com/mmaitland300/AuctionHouse",
-    category: "featured",
-  },
-  {
     slug: "full-swing-tech-support",
-    title: "Full Swing Technical Support Case Study",
+    title: "Full Swing Technical Support",
     description:
-      "Systems-focused support work across simulator hardware/software stacks, including diagnostics for calibration drift, networking/configuration failures, licensing issues, and Windows/peripheral conflicts.",
+      "My day job. I do remote support for Full Swing golf simulators — diagnosing issues that cross hardware, software, networking, and OS layers. This case study documents the triage approach I've built up from that work.",
     problem:
-      "Customers needed fast, accurate triage and resolution for multi-layer issues where hardware, software, and environment variables intersected.",
+      "Simulator issues rarely have one cause. A customer reports \"the ball isn't tracking\" and the root cause could be calibration drift, a licensing timeout, a network config problem, or a Windows update that broke a driver.",
     constraints:
-      "Failures crossed calibration, licensing, networking, display, and OS layers, often with incomplete information and high user frustration.",
+      "Incomplete information is the norm. Customers are frustrated, logs aren't always available, and you're working remotely across all of these layers at once.",
     tradeoff:
-      "Used structured triage and reproducible diagnostic paths instead of quick one-off fixes to reduce repeat incidents and speed future resolution.",
-    role: "Technical support specialist, incident triage, remote diagnostics, root-cause isolation, and customer-facing resolution guidance.",
+      "Slower upfront diagnosis instead of quick one-off fixes. Takes more time per ticket, but the same failure patterns stop coming back.",
+    role: "Technical support specialist at Auxillium, supporting Full Swing's commercial and residential simulator deployments.",
     outcome:
-      "Improved issue resolution quality by applying structured troubleshooting playbooks and reproducible diagnostic paths across recurring failure modes.",
-    outcomeType: "qualitative",
+      "Built repeatable triage workflows that I now use across calibration, licensing, display, networking, and OS subsystems. Documented publicly as a case study.",
     tags: [
       "Technical Support",
       "Troubleshooting",
@@ -155,61 +105,47 @@ export const projects: Project[] = [
     category: "featured",
   },
   {
+    slug: "snake-detector",
+    title: "Snake Detector (CNN)",
+    description:
+      "A CNN image classifier for snake species. The interesting part wasn't the model — it was learning how much dataset quality matters. I spent more time on stratified splits, augmentation, and confusion-matrix-driven error review than on architecture.",
+    problem:
+      "The raw dataset had class imbalance, noisy labels, and inconsistent image quality. Naive training runs looked fine on aggregate accuracy but generalized poorly.",
+    outcome:
+      "An end-to-end pipeline where every training run uses the same splits and metrics, and poor-performing classes surface in review instead of hiding in the average.",
+    tags: ["Python", "Machine Learning", "CNN", "Computer Vision"],
+    github: "https://github.com/mmaitland300/Snake-detector",
+    caseStudy: "/projects/snake-detector",
+    category: "experiment",
+  },
+  {
+    slug: "auction-house",
+    title: "Auction House",
+    description:
+      "A Django auction platform from CS50 Web. Users can create listings, place bids, manage watchlists, and browse by category. All bid validation and ownership rules are enforced server-side.",
+    problem:
+      "The main challenge was getting the bid logic right — ensuring server-side rules handle concurrent actions and edge cases like bidding on your own listing or closed auctions.",
+    outcome:
+      "A working multi-user auction app with auth, listing lifecycle, bid validation, watchlists, and category browsing.",
+    tags: ["Django", "Python", "PostgreSQL", "HTML/CSS"],
+    github: "https://github.com/mmaitland300/AuctionHouse",
+    category: "featured",
+  },
+  {
     slug: "sample-organizer",
     title: "Sample Library Organizer",
     description:
-      "A file organizer built for musicians and producers to sort and manage large sample libraries. Scans directories, categorizes files, and keeps collections clean.",
-    problem:
-      "Large sample libraries get messy fast, with thousands of files and inconsistent naming across dozens of folders.",
-    constraints:
-      "Needed predictable categorization and safe file operations across inconsistent folder structures and naming conventions.",
-    tradeoff:
-      "Prioritized deterministic rules and repeatable CLI workflows over heuristic automation to keep results understandable and reversible.",
-    role: "Solo developer, file system logic, categorization rules, and CLI interface.",
-    outcome:
-      "Replaced multi-hour manual folder walks with a single deterministic CLI pass (dry-run, explicit rules, reversible moves) for large libraries.",
-    outcomeType: "proxy",
+      "A Python CLI tool I built to sort my sample libraries. It scans directories, categorizes audio files by deterministic rules, and moves them into a clean folder structure. Supports dry-run so you can preview before committing.",
     image: "/images/projects/sample-organizer-loaded.png",
     tags: ["Python", "CLI", "File Systems"],
     github: "https://github.com/mmaitland300/organizer_project",
     category: "experiment",
   },
   {
-    slug: "music-production-neurochemical-entropy",
-    title: "Music Production (NEUROCHEMICAL ENTROPY)",
-    description:
-      "Original music production workflow focused on arrangement, sound design, mixing, and mastering, with repeatable session structure and quality-control checkpoints.",
-    problem:
-      "Creative sessions can become inconsistent and hard to finish without a reliable production workflow and objective review points.",
-    constraints:
-      "Needed to keep creative flexibility while maintaining repeatable technical quality across tracking, mix translation, and final master output.",
-    tradeoff:
-      "Used a structured production pipeline and staged quality checks instead of purely ad-hoc iteration to improve consistency and reduce rework.",
-    role:
-      "Solo artist/producer responsible for writing, recording, editing, mixing, mastering, and release preparation.",
-    outcome:
-      "Built a stable end-to-end production process with track examples published on the music page and SoundCloud profile.",
-    outcomeType: "proxy",
-    tags: ["Music Production", "Audio Engineering", "Mixing", "Mastering"],
-    demo: "/music",
-    category: "experiment",
-  },
-  {
     slug: "turn-based-rpg",
     title: "Turn-Based RPG",
     description:
-      "Browser-based turn-based RPG prototype exploring deterministic combat state, scene transitions, and lightweight game-loop architecture.",
-    problem:
-      "Needed a small interactive system to test turn-order logic, state transitions, and combat feedback without backend dependencies.",
-    constraints:
-      "Had to keep runtime simple and portable in-browser while handling scene changes, sprite state, and turn resolution predictably.",
-    tradeoff:
-      "Used straightforward Phaser scene/state patterns over heavier abstractions to prioritize clarity and predictable behavior during iteration.",
-    role:
-      "Solo developer responsible for gameplay loop, combat logic, scene orchestration, and browser delivery.",
-    outcome:
-      "Delivered a playable web prototype with stable turn sequencing and repeatable combat interactions embedded directly in the portfolio.",
-    outcomeType: "technical",
+      "A browser RPG prototype I built to learn Phaser's scene system. Turn-based combat, sprite movement, and scene transitions — all running client-side with no backend.",
     tags: ["JavaScript", "Phaser.js", "Game Dev", "RPG"],
     iframe: "/games/rpg/index.html",
     category: "experiment",
@@ -218,18 +154,7 @@ export const projects: Project[] = [
     slug: "atoms-simulation",
     title: "Atoms Simulation",
     description:
-      "Interactive particle simulation built to explore browser physics behavior, collision feedback, and animation performance under continuous updates.",
-    problem:
-      "Needed a compact sandbox for testing real-time motion and interaction patterns in a browser-rendered simulation.",
-    constraints:
-      "Simulation needed to remain smooth and understandable without introducing complex physics dependencies or heavy rendering overhead.",
-    tradeoff:
-      "Chose a simplified rule set and visual model to keep update loops fast and behavior readable rather than chasing high-fidelity physics.",
-    role:
-      "Solo developer handling simulation rules, rendering behavior, and interaction tuning.",
-    outcome:
-      "Shipped a lightweight interactive simulation that runs in-browser and demonstrates stable real-time update behavior.",
-    outcomeType: "technical",
+      "An interactive particle simulation built with Phaser. Mostly a sandbox for playing with collision detection and continuous animation loops in the browser.",
     tags: ["JavaScript", "Phaser.js", "Canvas", "Physics"],
     iframe: "/games/atoms/index.html",
     category: "experiment",
@@ -240,7 +165,7 @@ export function getFeaturedProjects() {
   return projects.filter((p) => p.category === "featured");
 }
 
-/** Curated subset for the homepage hero grid (strongest proof, least noise). */
+/** Curated subset for the homepage hero grid. */
 export function getHomepageFeaturedProjects(): Project[] {
   return HOMEPAGE_FEATURED_SLUGS.map((slug) => {
     const p = projects.find((x) => x.slug === slug);


### PR DESCRIPTION
## Summary

- Rewrote all project descriptions in src/content/projects.ts with varied voice and depth per project tier (full/medium/light)
- Removed outcomeType from the Project interface and all entries
- Removed the music production entry (belongs on /music, not in the projects array)
- Dropped role field from solo hobby projects
- Updated project-card.tsx to remove outcomeLabels and simplified outcome rendering
- Trimmed narration comments in contact.ts and stringflux-waitlist.ts to non-obvious intent only

## Editing rules applied

- No two adjacent project entries share the same rhetorical structure
- Full depth (StringFlux, Portfolio, Full Swing) keeps problem/constraints/tradeoff/outcome
- Medium (Snake Detector, Auction House) keeps problem and outcome only
- Light (Sample Organizer, RPG, Atoms) keeps description only

## Test plan

- [x] npm run lint passes
- [x] npm test passes (67/67)
- [x] npm run build passes
- [ ] Voice-review: read project copy, verify no two adjacent entries share sentence structure
