### PR TITLE
Wave 2: Docs and polish cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,80 +1,18 @@
-# Vercel deployment checklist
-# 1. Create the project in Vercel and connect this repo.
-# 2. In Vercel -> Project -> Settings -> Environment Variables, add every value below.
-# 3. Set each variable for Production at minimum. Add Preview/Development too if you want parity.
-# 4. Redeploy after changing any environment variable.
+# Required
+NEXT_PUBLIC_SITE_URL=https://your-domain.com
+RESEND_API_KEY=
+CONTACT_FROM_EMAIL=
+CONTACT_TO_EMAIL=
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 
-# -----------------------------------------------------------------------------
-# Required for first live deployment
-# -----------------------------------------------------------------------------
+# Optional — shown in footer/contact sidebar; defaults to contact@mmaitland.dev in code
+# NEXT_PUBLIC_CONTACT_EMAIL=
 
-# Public site URL
-# Vercel value for first launch:
-#   https://your-project-name.vercel.app
-# Later, after adding a custom domain, change this to:
-#   https://yourdomain.com
-NEXT_PUBLIC_SITE_URL=https://your-project-name.vercel.app
-
-# Public email shown in footer, About, Contact sidebar, and Resume.
-# Defaults to contact@mmaitland.dev in code. Only set this if the address changes.
-# NEXT_PUBLIC_CONTACT_EMAIL=contact@mmaitland.dev
-
-# Resend email delivery
-# Get this from Resend -> API Keys
-RESEND_API_KEY=re_xxxxxxxxxxxx
-
-# Verified sender address in Resend.
-# Sending is on a subdomain so it does not conflict with root-domain MX records (ImprovMX).
-# The send.mmaitland.dev subdomain is already verified in Resend - do not change those DNS records.
-CONTACT_FROM_EMAIL=contact@send.mmaitland.dev
-
-# Inbox email where contact form submissions are delivered.
-# Set this to the address where you want to receive form submissions.
-CONTACT_TO_EMAIL=your-inbox@example.com
-
-# Upstash Redis for durable rate limiting
-# Get both values from Upstash -> Redis database -> REST API
-UPSTASH_REDIS_REST_URL=https://xxxx.upstash.io
-UPSTASH_REDIS_REST_TOKEN=xxxxxxxxxxxx
-
-# -----------------------------------------------------------------------------
-# Optional for Phase 3 admin inbox persistence
-# -----------------------------------------------------------------------------
-
-# Neon pooled connection string used by the app at runtime
-# Neon dashboard label: Pooled connection / DATABASE_URL
-# Example:
-#   postgresql://user:pass@ep-xxx-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require
-# DATABASE_URL=postgresql://user:pass@host/db?sslmode=require
-
-# Neon direct connection string used by Prisma CLI
-# Neon dashboard label: Direct connection / DIRECT_URL
-# Example:
-#   postgresql://user:pass@ep-xxx-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require
-# DIRECT_URL=postgresql://user:pass@host/db?sslmode=require
-
-# -----------------------------------------------------------------------------
-# Optional for Phase 3 admin authentication
-# -----------------------------------------------------------------------------
-
-# Generate locally with:
-#   npx auth secret
-# Paste the generated value into Vercel exactly as produced.
-# AUTH_SECRET=generate-with-npx-auth-secret
-
-# GitHub OAuth App credentials
-# Create at:
-#   https://github.com/settings/developers
-# Authorization callback URL for production:
-#   https://your-project-name.vercel.app/api/auth/callback/github
-# Or, after adding a custom domain:
-#   https://yourdomain.com/api/auth/callback/github
-# AUTH_GITHUB_ID=your-github-oauth-app-id
-# AUTH_GITHUB_SECRET=your-github-oauth-app-secret
-
-# Comma-separated GitHub numeric user IDs allowed into /admin
-# Find your numeric ID at:
-#   https://api.github.com/users/YOUR_GITHUB_USERNAME
-# Example:
-#   12345678
-# ADMIN_GITHUB_IDS=12345678
+# Optional (admin + persistence)
+# DATABASE_URL=
+# DIRECT_URL=
+# AUTH_SECRET=
+# AUTH_GITHUB_ID=
+# AUTH_GITHUB_SECRET=
+# ADMIN_GITHUB_IDS=

--- a/README.md
+++ b/README.md
@@ -98,28 +98,6 @@ Set `published: false` to keep a post as a draft (hidden from listings and direc
 
 **Resume data** is centralized in `src/content/resume.ts` and consumed by both the `/about` and `/resume` pages.
 
-## Operational Decisions
-
-These are intentional tradeoffs built into the app. They are documented here so they are visible at the repo level, not just in code comments.
-
-**Contact pipeline: email is source of truth, inbox is best-effort.**
-The contact form sends email via Resend before attempting database persistence. If Prisma fails after a successful send, the user still gets a success response and the email is delivered. The admin inbox may miss that message. This is an intentional tradeoff: guaranteed delivery over guaranteed persistence.
-
-**StringFlux waitlist sends two emails when Resend is configured.**
-On signup, the app sends an internal notification to `CONTACT_TO_EMAIL` so new entries are visible without checking the admin page. It also sends a confirmation email to the subscriber address. Both emails are best-effort; the durable source of truth is the database row.
-
-**Public contact address is decoupled from delivery address.**
-`contact@mmaitland.dev` (via ImprovMX forwarding) is what visitors see on the site. `CONTACT_TO_EMAIL` controls where form submissions actually go (currently the Gmail address directly). These are separate so the public-facing address can change without touching the app.
-
-**Admin gating uses GitHub numeric user IDs, not email.**
-`ADMIN_GITHUB_IDS` contains stable numeric IDs (e.g. `68873951`), not emails. GitHub user IDs do not change; email-based gating is unreliable because of privacy settings and address changes.
-
-**Rate limiting is durable, not in-memory.**
-The contact form uses Upstash Redis for rate limiting. In-memory state is not reliable across Vercel function instances. Upstash provides durable, globally consistent counters.
-
-**Database and auth are optional, but they gate specific features.**
-The site runs without `DATABASE_URL` or auth credentials. Without a database, the contact form still sends email, but the StringFlux waitlist and admin inbox are disabled. Admin access additionally requires `AUTH_SECRET`, `AUTH_GITHUB_ID`, and `AUTH_GITHUB_SECRET`.
-
 ## Scripts
 
 | Command | Description |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,19 +9,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -47,6 +34,7 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/* Light theme retained for future toggle */
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -66,20 +54,7 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 282);
-  --chart-2: oklch(0.715 0.143 215);
-  --chart-3: oklch(0.720 0.189 197);
-  --chart-4: oklch(0.680 0.162 293);
-  --chart-5: oklch(0.750 0.170 190);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
@@ -101,19 +76,6 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.646 0.222 282);
-  --chart-2: oklch(0.715 0.143 215);
-  --chart-3: oklch(0.720 0.189 197);
-  --chart-4: oklch(0.680 0.162 293);
-  --chart-5: oklch(0.750 0.170 190);
-  --sidebar: oklch(0.12 0 0);
-  --sidebar-foreground: oklch(0.95 0 0);
-  --sidebar-primary: oklch(0.646 0.222 282);
-  --sidebar-primary-foreground: oklch(0.95 0 0);
-  --sidebar-accent: oklch(0.18 0 0);
-  --sidebar-accent-foreground: oklch(0.95 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/src/app/projects/full-swing-tech-support/page.tsx
+++ b/src/app/projects/full-swing-tech-support/page.tsx
@@ -213,7 +213,7 @@ export default function FullSwingCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <CheckCircle2 className="h-5 w-5 text-emerald-400" />
-            <h2 className="text-xl font-semibold">Outcome Signal</h2>
+            <h2 className="text-xl font-semibold">Results</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">

--- a/src/app/projects/stringflux/page.tsx
+++ b/src/app/projects/stringflux/page.tsx
@@ -245,7 +245,7 @@ export default function StringFluxCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <AudioLines className="h-5 w-5 text-rose-400" />
-            <h2 className="text-xl font-semibold">Current Outcome Signal</h2>
+            <h2 className="text-xl font-semibold">Where It Stands</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">

--- a/src/content/blog/building-this-site.mdx
+++ b/src/content/blog/building-this-site.mdx
@@ -64,8 +64,4 @@ export async function submitContact(
 
 Phase 2 added the blog you're reading now. Phase 3 brought database persistence with Prisma and Neon PostgreSQL, a contact inbox with archive/restore, and GitHub OAuth via Auth.js for admin access. A `/music` page with SoundCloud embeds was added outside the original roadmap.
 
-Still on the list:
-
-- Command palette navigation
-- Dark/light mode toggle
-- Lighthouse optimization pass
+The site is live and under active iteration. The current focus is on tightening content quality and reducing any patterns that feel templated or mechanical.

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -19,7 +19,7 @@ export type ResumeExperienceItem = {
 };
 
 export const resumeSummary =
-  "Colorado-based developer and technical support professional focused on practical software, reliable systems, and clear problem solving. Experience includes building full-stack web applications, integrating APIs, deploying production systems, and supporting users through hardware, software, and connectivity issues.";
+  "I'm a developer and technical support specialist based in Colorado. I build full-stack web applications and support Full Swing golf simulator systems. My work ranges from Next.js and Django apps to remote hardware/software troubleshooting across production environments.";
 
 export const resumeSkills = [
   "TypeScript",
@@ -57,11 +57,11 @@ export const resumeExperience: ResumeExperienceItem[] = [
       "Build custom web applications and software solutions with Django, Flask, React, and Next.js. Handle database design, API integrations, debugging, deployment, and long-term client support from launch through maintenance.",
     highlights: [
       {
-        text: "Built and shipped mmaitland.dev (Next.js, Prisma, Auth.js) with validated contact intake, rate limiting, and admin OAuth.",
+        text: "Built and shipped this portfolio site (Next.js, Prisma, Auth.js) with contact form, rate limiting, and admin inbox.",
         href: "https://www.mmaitland.dev",
       },
       {
-        text: "StringFlux product page: transient-aware multiband granular delay/freeze plugin currently in active development.",
+        text: "Building StringFlux, a multiband granular delay/freeze audio plugin for guitar.",
         href: "https://www.mmaitland.dev/stringflux",
       },
     ],
@@ -74,11 +74,11 @@ export const resumeExperience: ResumeExperienceItem[] = [
       "Deliver technical support for Full Swing simulator software and hardware, resolving installation, calibration, licensing, display, networking, and performance issues across commercial and residential environments.",
     highlights: [
       {
-        text: "Standardized multi-layer triage workflows across calibration, licensing, display, networking, and OS subsystems (documented publicly).",
+        text: "Built triage workflows for recurring simulator issues across calibration, licensing, display, networking, and OS layers.",
         href: "/projects/full-swing-tech-support",
       },
       {
-        text: "Reduced repeat incidents on recurring failure classes by converting ad-hoc fixes into reproducible diagnostic playbooks.",
+        text: "Turned common one-off fixes into documented playbooks so the same problems stop coming back.",
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Removed Operational Decisions section from README.md (content lives in blog posts)
- Flattened .env.example from 80-line tutorial to standard key-per-line format
- Rewrote resume.ts summary and highlights in natural first-person voice
- Removed unused sidebar and chart scaffold tokens from globals.css
- Replaced Outcome Signal headings in stringflux and full-swing case study pages
- Removed stale roadmap items from building-this-site.mdx

## Commits (6)

1. docs(readme): remove operational decisions section
2. docs(env): flatten env example to standard format
3. content(resume): rewrite summary and highlights in natural voice
4. refactor(css): remove unused sidebar and chart scaffold
5. content(case-studies): replace Outcome Signal headings
6. content(blog): remove stale roadmap items

## Test plan

- [x] npm run lint passes
- [x] npm test passes (67/67)
- [x] npm run build passes (25 static pages generated)
- [ ] Verify globals.css light theme still renders if dark class is removed (retained for future toggle)
