### PR TITLE
Wave 3: Trust-path tests, navbar fix, evidence parity, homepage proof, per-page OG

### DIFF
--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,4 +1,4 @@
-﻿import { test, expect } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 const publicRoutes = [
   "/",
@@ -33,4 +33,52 @@ test("admin/login renders without error", async ({ page }) => {
   );
 });
 
+test("every public route has a <title> and meta description", async ({
+  page,
+}) => {
+  for (const route of publicRoutes) {
+    await page.goto(route);
+    const title = await page.title();
+    expect(title, `${route} missing <title>`).toBeTruthy();
+    expect(title.length, `${route} <title> too short`).toBeGreaterThan(5);
 
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content");
+    expect(description, `${route} missing meta description`).toBeTruthy();
+  }
+});
+
+test("OG meta tags present on homepage", async ({ page }) => {
+  await page.goto("/");
+  const ogTitle = await page
+    .locator('meta[property="og:title"]')
+    .getAttribute("content");
+  expect(ogTitle).toBeTruthy();
+
+  const ogDescription = await page
+    .locator('meta[property="og:description"]')
+    .getAttribute("content");
+  expect(ogDescription).toBeTruthy();
+
+  const ogImage = await page
+    .locator('meta[property="og:image"]')
+    .getAttribute("content");
+  expect(ogImage).toBeTruthy();
+});
+
+test("not-found page returns 404 status", async ({ page }) => {
+  const response = await page.goto("/this-route-does-not-exist");
+  expect(response?.status()).toBe(404);
+});
+
+test("navbar links are visible on desktop", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+  const nav = page.locator("nav");
+  await expect(nav).toBeVisible();
+
+  for (const label of ["Projects", "About", "Blog", "Contact"]) {
+    await expect(nav.getByRole("link", { name: label })).toBeVisible();
+  }
+});

--- a/src/app/about/opengraph-image.tsx
+++ b/src/app/about/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { createOgImage, ogSize } from "@/lib/og-image";
 
 export const runtime = "edge";
-export const alt = "Matt Maitland | Software Developer & Technical Support";
+export const alt = "About | Matt Maitland";
 export const size = ogSize;
 export const contentType = "image/png";
 
 export default function OgImage() {
-  return createOgImage("Matt Maitland", "Software Developer & Technical Support");
+  return createOgImage("About", "Developer and technical support specialist based in Colorado");
 }

--- a/src/app/blog/opengraph-image.tsx
+++ b/src/app/blog/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { createOgImage, ogSize } from "@/lib/og-image";
 
 export const runtime = "edge";
-export const alt = "Matt Maitland | Software Developer & Technical Support";
+export const alt = "Blog | Matt Maitland";
 export const size = ogSize;
 export const contentType = "image/png";
 
 export default function OgImage() {
-  return createOgImage("Matt Maitland", "Software Developer & Technical Support");
+  return createOgImage("Blog", "Technical writing on web development, DSP, and engineering decisions");
 }

--- a/src/app/contact/opengraph-image.tsx
+++ b/src/app/contact/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { createOgImage, ogSize } from "@/lib/og-image";
 
 export const runtime = "edge";
-export const alt = "Matt Maitland | Software Developer & Technical Support";
+export const alt = "Contact | Matt Maitland";
 export const size = ogSize;
 export const contentType = "image/png";
 
 export default function OgImage() {
-  return createOgImage("Matt Maitland", "Software Developer & Technical Support");
+  return createOgImage("Contact", "Get in touch — project inquiries, collaboration, or just to say hello");
 }

--- a/src/app/projects/opengraph-image.tsx
+++ b/src/app/projects/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { createOgImage, ogSize } from "@/lib/og-image";
 
 export const runtime = "edge";
-export const alt = "Matt Maitland | Software Developer & Technical Support";
+export const alt = "Projects | Matt Maitland";
 export const size = ogSize;
 export const contentType = "image/png";
 
 export default function OgImage() {
-  return createOgImage("Matt Maitland", "Software Developer & Technical Support");
+  return createOgImage("Projects", "Web apps, audio plugins, ML experiments, and case studies");
 }

--- a/src/app/projects/portfolio-site/page.tsx
+++ b/src/app/projects/portfolio-site/page.tsx
@@ -1,4 +1,4 @@
-﻿import type { Metadata } from "next";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle2, FileCode2, ShieldCheck } from "lucide-react";
@@ -17,7 +17,7 @@ const safeguards = [
   "Honeypot plus Upstash sliding-window limiting on inbound actions",
   "Auth.js GitHub OAuth gate for admin routes and inbox views",
   "Prisma-backed persistence for contact/waitlist records",
-  "Playwright smoke coverage on trust-critical routes",
+  "Playwright smoke coverage on all public routes with metadata and OG verification",
 ];
 
 const tradeoffs = [
@@ -159,13 +159,12 @@ export default function PortfolioSiteCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <CheckCircle2 className="h-5 w-5 text-emerald-400" />
-            <h2 className="text-xl font-semibold">Outcome signal</h2>
+            <h2 className="text-xl font-semibold">Where it stands</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            <span className="font-medium text-foreground">Operational proxy:</span>{" "}
-            a production portfolio that can reliably receive contact, protect
-            admin-only surfaces, and expose engineering reasoning through linked
-            decision records and case-study artifacts.
+            The site reliably receives contact, protects admin surfaces behind
+            OAuth, and documents its own engineering decisions through linked blog
+            posts and case studies. It&apos;s live, tested, and under active iteration.
           </p>
         </section>
       </div>

--- a/src/app/projects/snake-detector/page.tsx
+++ b/src/app/projects/snake-detector/page.tsx
@@ -103,14 +103,13 @@ export default function SnakeDetectorCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <BarChart3 className="h-5 w-5 text-amber-400" />
-            <h2 className="text-xl font-semibold">Outcome signal</h2>
+            <h2 className="text-xl font-semibold">Where it stands</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            <span className="font-medium text-foreground">Technical outcome:</span>{" "}
-            a repeatable loop where poor classes show up in structured review
-            instead of hiding behind a single accuracy number. The repo is the
-            source of truth for scripts and training flow; plug in your own
-            metrics exports or confusion matrices as you iterate.
+            The pipeline produces a repeatable training loop where poorly-performing
+            species surface in structured review instead of hiding behind aggregate
+            accuracy. The repo contains the full training flow, split configuration,
+            and evaluation scripts.
           </p>
         </section>
       </div>

--- a/src/app/resume/opengraph-image.tsx
+++ b/src/app/resume/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { createOgImage, ogSize } from "@/lib/og-image";
 
 export const runtime = "edge";
-export const alt = "Matt Maitland | Software Developer & Technical Support";
+export const alt = "Resume | Matt Maitland";
 export const size = ogSize;
 export const contentType = "image/png";
 
 export default function OgImage() {
-  return createOgImage("Matt Maitland", "Software Developer & Technical Support");
+  return createOgImage("Resume", "Experience, skills, and education");
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -20,12 +20,50 @@ export function Navbar() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  const closeMobile = useCallback(() => setMobileOpen(false), []);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
+
+  useEffect(() => {
+    closeMobile();
+  }, [pathname, closeMobile]);
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    document.body.style.overflow = "hidden";
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeMobile();
+    };
+
+    const onClickOutside = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        toggleRef.current &&
+        !toggleRef.current.contains(e.target as Node)
+      ) {
+        closeMobile();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("mousedown", onClickOutside);
+
+    return () => {
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("mousedown", onClickOutside);
+    };
+  }, [mobileOpen, closeMobile]);
 
   return (
     <header
@@ -40,7 +78,7 @@ export function Navbar() {
         <Link
           href="/"
           className="text-xl font-bold tracking-tight"
-          onClick={() => setMobileOpen(false)}
+          onClick={closeMobile}
         >
           <span className="brand-mark">
             M<span className="brand-accent">M</span>
@@ -85,48 +123,54 @@ export function Navbar() {
 
         {/* Mobile toggle */}
         <button
+          ref={toggleRef}
           className="md:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-label={mobileOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileOpen}
         >
           {mobileOpen ? <X size={22} /> : <Menu size={22} />}
         </button>
       </nav>
 
       {/* Mobile menu */}
-      {mobileOpen && (
-        <motion.div
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          className="md:hidden bg-background/95 backdrop-blur-lg border-b border-border"
-        >
-          <ul className="flex flex-col px-6 py-4 gap-1">
-            {links.map((link) => {
-              const isActive =
-                link.href === "/"
-                  ? pathname === "/"
-                  : pathname.startsWith(link.href);
-              return (
-                <li key={link.href}>
-                   <Link
-                     href={link.href}
-                     onClick={() => setMobileOpen(false)}
-                     className={cn(
-                       "block px-4 py-3 text-sm font-medium rounded-md transition-colors",
-                       isActive
-                        ? "text-foreground bg-muted"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                    )}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </motion.div>
-      )}
+      <AnimatePresence>
+        {mobileOpen && (
+          <motion.div
+            ref={menuRef}
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.2 }}
+            className="md:hidden bg-background/95 backdrop-blur-lg border-b border-border"
+          >
+            <ul className="flex flex-col px-6 py-4 gap-1">
+              {links.map((link) => {
+                const isActive =
+                  link.href === "/"
+                    ? pathname === "/"
+                    : pathname.startsWith(link.href);
+                return (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      onClick={closeMobile}
+                      className={cn(
+                        "block px-4 py-3 text-sm font-medium rounded-md transition-colors",
+                        isActive
+                          ? "text-foreground bg-muted"
+                          : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      )}
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </header>
   );
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -32,10 +32,6 @@ export function Navbar() {
   }, []);
 
   useEffect(() => {
-    closeMobile();
-  }, [pathname, closeMobile]);
-
-  useEffect(() => {
     if (!mobileOpen) return;
 
     document.body.style.overflow = "hidden";

--- a/src/components/sections/proof-strip.tsx
+++ b/src/components/sections/proof-strip.tsx
@@ -4,24 +4,26 @@ const proofItems = [
   {
     title: "Production simulator support under real constraints",
     detail:
-      "Full-time incident triage at Auxillium for Full Swing GOLF software and simulator systems (2024-present).",
+      "Full-time incident triage at Auxillium for Full Swing simulator systems — hardware, software, networking, and OS layers (2024–present).",
     href: "/projects/full-swing-tech-support",
   },
   {
     title: "Web delivery with auth and abuse controls",
     detail:
-      "Live Next.js stack with admin OAuth, server-side validation, and contact intake protections.",
+      "This site: Next.js 16, server-side validation, honeypot + Redis rate limiting, GitHub OAuth admin inbox. Documented in a public decision record.",
     href: "/blog/contact-pipeline-decision-record",
   },
   {
-    title: "StringFlux DSP development",
+    title: "StringFlux — audio plugin in active development",
     detail:
-      "JUCE/C++ plugin work: multiband routing, transient-driven grain scheduling, and safe oversampling transitions.",
+      "JUCE/C++ multiband granular delay with transient-driven grain scheduling and real-time safe oversampling transitions.",
     href: "/projects/stringflux",
   },
   {
-    title: "Core stack in active use",
-    detail: "Next.js, TypeScript, Python, C++, PostgreSQL.",
+    title: "ML evaluation discipline",
+    detail:
+      "CNN snake classifier focused on dataset hygiene, stratified splits, and confusion-matrix-driven review before architecture changes.",
+    href: "/projects/snake-detector",
   },
 ];
 

--- a/src/lib/og-image.tsx
+++ b/src/lib/og-image.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from "next/og";
+
+export const ogSize = { width: 1200, height: 630 };
+
+export function createOgImage(title: string, subtitle: string) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 20,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 60,
+              fontWeight: 800,
+              background: "linear-gradient(135deg, #8b5cf6, #06b6d4)",
+              backgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            {title}
+          </div>
+          <div
+            style={{
+              fontSize: 26,
+              color: "#a1a1aa",
+              textAlign: "center",
+              maxWidth: 800,
+            }}
+          >
+            {subtitle}
+          </div>
+          <div
+            style={{
+              fontSize: 18,
+              color: "#52525b",
+              marginTop: 12,
+            }}
+          >
+            mmaitland.dev
+          </div>
+        </div>
+      </div>
+    ),
+    { ...ogSize }
+  );
+}


### PR DESCRIPTION
## Summary

Addresses all five P1-P3 findings from the post-Wave-2 evaluation.

### Trust-path smoke tests (P1)
- Expanded routes.spec.ts from basic GET/200 checks to include metadata verification (title + description on all public routes), OG tag checks on homepage, 404 status test, and desktop nav link visibility

### Navbar mobile-menu cleanup (P1)
- Wrapped mobile menu in AnimatePresence so exit animation fires
- Added Escape key handler, outside-click close, and scroll lock when open
- Added aria-expanded to toggle button
- Removed pathname-change effect (link onClick handlers already close the menu; lint rules prevent both effect-based and render-based alternatives)

### Evidence parity (P2)
- Replaced final two Outcome signal headings (lowercase s) on portfolio-site and snake-detector case study pages
- Updated portfolio safeguards claim to reflect expanded test coverage
- Zero instances of Outcome Signal/signal remain in codebase (case-insensitive verified)

### Homepage proof copy (P3)
- Replaced generic Core stack in active use tile with linked ML evidence tile (Snake Detector case study)
- All four proof strip tiles now link to concrete evidence pages
- Sharpened detail copy across all tiles

### Per-page OG images (P2)
- Created shared OG image utility (src/lib/og-image.tsx) for consistent styling
- Added route-specific OG images for /projects, /blog, /about, /contact, /resume
- Refactored root OG image to use shared utility
- Build confirms all OG routes registered as dynamic endpoints

## Commits (6)

1. test(e2e): expand route smoke tests with metadata, OG, 404, and nav checks
2. fix(navbar): add AnimatePresence, Escape, outside click, scroll lock, pathname close
3. content(case-studies): kill remaining Outcome signal headings, update safeguards claim
4. content(homepage): replace generic stack tile with linked ML evidence
5. feat(og): add per-route OG images for projects, blog, about, contact, resume
6. fix(navbar): remove pathname effect to satisfy set-state-in-effect lint rule

## Test plan

- [x] npm run lint passes (0 errors, 0 warnings)
- [x] npm test passes (67/67)
- [x] npm run build passes (25 static pages, 6 OG image routes registered)
- [x] Case-insensitive grep for Outcome Signal returns zero matches
- [ ] Manual: verify mobile menu opens/closes, Escape closes, outside click closes, scroll locked when open
- [ ] Manual: verify OG images render on social preview tools
