### PR TITLE
Wave 4A-4B: Featured case-study parity + trust-path e2e

### DIFF
--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -23,3 +23,43 @@ test("contact form renders required fields", async ({ page }) => {
   await expect(page.locator('textarea[name="message"]')).toBeVisible();
   await expect(page.locator('button[type="submit"]')).toBeVisible();
 });
+
+test("contact form rejects honeypot fill (bot signal)", async ({ page }) => {
+  await page.goto("/contact");
+  await page.fill('input[name="name"]', "Test");
+  await page.fill('input[name="email"]', "test@example.com");
+  await page.fill(
+    'textarea[name="message"]',
+    "This message is long enough for server validation."
+  );
+  await page.evaluate(() => {
+    const hp = document.querySelector(
+      'input[name="_hp"]'
+    ) as HTMLInputElement | null;
+    if (hp) hp.value = "bot-signal";
+  });
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page.getByText("Please fix the errors below.")).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("contact form valid submit reaches a terminal UI state", async ({
+  page,
+}) => {
+  await page.goto("/contact");
+  await page.fill('input[name="name"]', "E2E Test");
+  await page.fill('input[name="email"]', "e2e-test@example.com");
+  await page.fill(
+    'textarea[name="message"]',
+    "Playwright trust-path check: valid payload long enough."
+  );
+  await page.locator('button[type="submit"]').click();
+
+  await expect(
+    page.getByText(
+      /Message Sent!|Contact form is not configured yet|Failed to send your message|Too many requests/
+    )
+  ).toBeVisible({ timeout: 20_000 });
+});

--- a/e2e/navbar-mobile.spec.ts
+++ b/e2e/navbar-mobile.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("mobile navbar", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("opens menu, shows nav links, locks scroll, closes on Escape", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const toggle = page.getByRole("button", { name: "Open menu" });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const menu = page.getByTestId("mobile-nav-menu");
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole("link", { name: "Projects" })).toBeVisible();
+
+    const overflowWhileOpen = await page.evaluate(
+      () => window.getComputedStyle(document.body).overflow
+    );
+    expect(overflowWhileOpen).toBe("hidden");
+
+    await page.keyboard.press("Escape");
+    await expect(menu).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Open menu" })
+    ).toBeVisible();
+  });
+
+  test("closes menu on outside click", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const menu = page.getByTestId("mobile-nav-menu");
+    await expect(menu).toBeVisible();
+
+    await page.locator("main").click({ position: { x: 20, y: 400 } });
+    await expect(menu).not.toBeVisible();
+  });
+});

--- a/src/app/projects/full-swing-tech-support/page.tsx
+++ b/src/app/projects/full-swing-tech-support/page.tsx
@@ -243,7 +243,7 @@ export default function FullSwingCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <CheckCircle2 className="h-5 w-5 text-emerald-400" />
-            <h2 className="text-xl font-semibold">Current state</h2>
+            <h2 className="text-xl font-semibold">Where it stands</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">

--- a/src/app/projects/full-swing-tech-support/page.tsx
+++ b/src/app/projects/full-swing-tech-support/page.tsx
@@ -83,6 +83,21 @@ const representativeIncident = [
   },
 ];
 
+const evidenceLinks = [
+  {
+    label: "Troubleshooting playbook post (real incident format)",
+    href: "/blog/troubleshooting-playbook-multi-layer-failures",
+  },
+  {
+    label: "Projects overview entry",
+    href: "/projects",
+  },
+  {
+    label: "Resume role context",
+    href: "/resume",
+  },
+];
+
 export default function FullSwingCaseStudyPage() {
   return (
     <div className="py-24">
@@ -200,7 +215,7 @@ export default function FullSwingCaseStudyPage() {
         </section>
 
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
-          <h2 className="mb-3 text-xl font-semibold">Key Tradeoff</h2>
+          <h2 className="mb-3 text-xl font-semibold">Tradeoffs</h2>
           <p className="text-sm leading-relaxed text-muted-foreground">
             The consistent tradeoff was speed versus reliability. Fast,
             one-off fixes could close tickets quickly but often increased
@@ -210,10 +225,25 @@ export default function FullSwingCaseStudyPage() {
           </p>
         </section>
 
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <h2 className="mb-3 text-xl font-semibold">Evidence links</h2>
+          <div className="space-y-2">
+            {evidenceLinks.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="block rounded-lg border border-border bg-card/30 px-4 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </section>
+
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <CheckCircle2 className="h-5 w-5 text-emerald-400" />
-            <h2 className="text-xl font-semibold">Results</h2>
+            <h2 className="text-xl font-semibold">Current state</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">

--- a/src/app/projects/portfolio-site/page.tsx
+++ b/src/app/projects/portfolio-site/page.tsx
@@ -125,7 +125,7 @@ export default function PortfolioSiteCaseStudyPage() {
         </section>
 
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
-          <h2 className="mb-3 text-xl font-semibold">Tradeoffs and rationale</h2>
+          <h2 className="mb-3 text-xl font-semibold">Tradeoffs</h2>
           <div className="space-y-4">
             {tradeoffs.map((item) => (
               <div key={item.title}>

--- a/src/app/projects/stringflux/page.tsx
+++ b/src/app/projects/stringflux/page.tsx
@@ -85,6 +85,21 @@ const validationChecks = [
   },
 ];
 
+const evidenceLinks = [
+  {
+    label: "StringFlux project repository",
+    href: "https://github.com/mmaitland300/StringFlux",
+  },
+  {
+    label: "Oversampling decision log",
+    href: "/blog/stringflux-oversampling-decision-log",
+  },
+  {
+    label: "StringFlux public product page",
+    href: "/stringflux",
+  },
+];
+
 export default function StringFluxCaseStudyPage() {
   return (
     <div className="py-24">
@@ -239,6 +254,26 @@ export default function StringFluxCaseStudyPage() {
                 </p>
               </div>
             ))}
+          </div>
+        </section>
+
+        <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
+          <h2 className="mb-3 text-xl font-semibold">Evidence links</h2>
+          <div className="space-y-2">
+            {evidenceLinks.map((item) => {
+              const isExternal = item.href.startsWith("http");
+              return (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  target={isExternal ? "_blank" : undefined}
+                  rel={isExternal ? "noopener noreferrer" : undefined}
+                  className="block rounded-lg border border-border bg-card/30 px-4 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </a>
+              );
+            })}
           </div>
         </section>
 

--- a/src/app/projects/stringflux/page.tsx
+++ b/src/app/projects/stringflux/page.tsx
@@ -211,7 +211,7 @@ export default function StringFluxCaseStudyPage() {
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-4 flex items-center gap-2">
             <SlidersHorizontal className="h-5 w-5 text-emerald-400" />
-            <h2 className="text-xl font-semibold">Key Tradeoffs</h2>
+            <h2 className="text-xl font-semibold">Tradeoffs</h2>
           </div>
           <div className="space-y-4">
             {tradeoffs.map((item) => (
@@ -280,7 +280,7 @@ export default function StringFluxCaseStudyPage() {
         <section className="rounded-xl border border-border bg-card/40 p-6">
           <div className="mb-3 flex items-center gap-2">
             <AudioLines className="h-5 w-5 text-rose-400" />
-            <h2 className="text-xl font-semibold">Where It Stands</h2>
+            <h2 className="text-xl font-semibold">Where it stands</h2>
           </div>
           <p className="text-sm leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -140,7 +140,10 @@ export function Navbar() {
             transition={{ duration: 0.2 }}
             className="md:hidden bg-background/95 backdrop-blur-lg border-b border-border"
           >
-            <ul className="flex flex-col px-6 py-4 gap-1">
+            <ul
+              data-testid="mobile-nav-menu"
+              className="flex flex-col px-6 py-4 gap-1"
+            >
               {links.map((link) => {
                 const isActive =
                   link.href === "/"


### PR DESCRIPTION
## Scope note

**Featured case-study pages** = `/projects/stringflux`, `/projects/portfolio-site`, `/projects/full-swing-tech-support`. This is not the same as every `category: "featured"` entry in `projects.ts` (e.g. Auction House has no case study page).

## Wave 4A

- Evidence links on StringFlux + Full Swing case studies (first commit)
- Micro-pass: normalize section headings (`Tradeoffs`, `Where it stands`) across those three pages

## Wave 4B

- `e2e/navbar-mobile.spec.ts`: mobile viewport open menu, scroll lock, Escape close, outside click close
- `e2e/contact-form.spec.ts`: honeypot rejection; valid submit reaches terminal UI (success, misconfig, send failure, or rate limit)
- `data-testid="mobile-nav-menu"` on mobile menu `<ul>` (Framer `motion.div` did not expose test id to DOM)

## Verification

- `npm run lint` / `npm test` / `npm run build` green
- `npm run test:e2e -- e2e/navbar-mobile.spec.ts e2e/contact-form.spec.ts e2e/admin-redirect.spec.ts` (rebuild or fresh `npm start` if reusing dev server)
