### PR TITLE
Wave 4D: blog article OG e2e, nav a11y assertions, reduced-motion MotionConfig

### DIFF
--- a/e2e/blog-post-meta.spec.ts
+++ b/e2e/blog-post-meta.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+/** Stable published post; blog generateMetadata sets article OG fields. */
+const BLOG_POST_PATH = "/blog/building-this-site";
+
+test("blog post exposes article Open Graph metadata", async ({ page }) => {
+  await page.goto(BLOG_POST_PATH);
+  expect(page.url()).toContain(BLOG_POST_PATH);
+
+  await expect(
+    page.locator('meta[property="og:type"]')
+  ).toHaveAttribute("content", "article");
+
+  const published = page.locator('meta[property="article:published_time"]');
+  await expect(published).toHaveCount(1);
+  const content = await published.getAttribute("content");
+  expect(content).toBeTruthy();
+  expect(content?.length).toBeGreaterThan(4);
+});

--- a/e2e/navbar-mobile.spec.ts
+++ b/e2e/navbar-mobile.spec.ts
@@ -10,7 +10,11 @@ test.describe("mobile navbar", () => {
 
     const toggle = page.getByRole("button", { name: "Open menu" });
     await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await toggle.click();
+
+    const closeToggle = page.getByRole("button", { name: "Close menu" });
+    await expect(closeToggle).toHaveAttribute("aria-expanded", "true");
 
     const menu = page.getByTestId("mobile-nav-menu");
     await expect(menu).toBeVisible();
@@ -23,9 +27,13 @@ test.describe("mobile navbar", () => {
 
     await page.keyboard.press("Escape");
     await expect(menu).not.toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Open menu" })
-    ).toBeVisible();
+    const reopenToggle = page.getByRole("button", { name: "Open menu" });
+    await expect(reopenToggle).toBeVisible();
+    await expect(reopenToggle).toHaveAttribute("aria-expanded", "false");
+    const overflowAfterClose = await page.evaluate(
+      () => window.getComputedStyle(document.body).overflow
+    );
+    expect(overflowAfterClose).not.toBe("hidden");
   });
 
   test("closes menu on outside click", async ({ page }) => {
@@ -37,5 +45,12 @@ test.describe("mobile navbar", () => {
 
     await page.locator("main").click({ position: { x: 20, y: 400 } });
     await expect(menu).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Open menu" })
+    ).toHaveAttribute("aria-expanded", "false");
+    const overflowAfterClose = await page.evaluate(
+      () => window.getComputedStyle(document.body).overflow
+    );
+    expect(overflowAfterClose).not.toBe("hidden");
   });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { MotionProvider } from "@/components/layout/motion-provider";
 import { getSiteUrl } from "@/lib/site-url";
 import "./globals.css";
 
@@ -58,10 +59,12 @@ export default function RootLayout({
       className={`${inter.variable} ${jetbrainsMono.variable} dark h-full antialiased`}
     >
       <body className="min-h-full flex flex-col relative">
-        <div className="animated-bg-glow" aria-hidden="true" />
-        <Navbar />
-        <main className="flex-1 relative z-10">{children}</main>
-        <Footer />
+        <MotionProvider>
+          <div className="animated-bg-glow" aria-hidden="true" />
+          <Navbar />
+          <main className="flex-1 relative z-10">{children}</main>
+          <Footer />
+        </MotionProvider>
       </body>
     </html>
   );

--- a/src/components/layout/motion-provider.tsx
+++ b/src/components/layout/motion-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+/**
+ * Respects prefers-reduced-motion for all Framer Motion usage under this tree.
+ */
+export function MotionProvider({ children }: { children: React.ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}


### PR DESCRIPTION
## Wave 4D (narrow)

### Metadata
- New `e2e/blog-post-meta.spec.ts`: one route (`/blog/building-this-site`) asserts `og:type=article` and `article:published_time` is present (matches `generateMetadata` in blog post page).
- No canonical or Twitter field assertions (not standardized beyond root layout defaults).

### Interaction
- `e2e/navbar-mobile.spec.ts`: assert `aria-expanded` true when menu open (`Close menu`), false after Escape/outside close; assert `body` overflow is not `hidden` after close.

### Reduced motion (Framer)
- `MotionProvider` wraps shell with `MotionConfig reducedMotion="user"` so Motion respects `prefers-reduced-motion`.

## Verification
- `npm run lint`, `npm test`, `npm run build`
- `npm run test:e2e -- e2e/blog-post-meta.spec.ts e2e/navbar-mobile.spec.ts`
