### PR TITLE
docs: align CONTRIBUTING merge policy; README clone matches package name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,16 +20,19 @@ Rules:
 - Keep `summary` concise and imperative.
 - Add `scope` when a specific area is clear (`ci`, `admin`, `projects`, `docs`, etc.).
 - Recommended types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
-- Avoid generic subjects like `update`, `misc`, or `merge: ...`.
+- Avoid generic subjects like `update` or `misc` for local WIP commits.
+- GitHub merge commits titled `Merge pull request #…` are normal on `main` and do not need to follow the `type(scope):` pattern.
 
-## Merge Policy
+## Merge policy
 
-For `main`, prefer one policy and apply it consistently:
+- Land work on **`main`** through **pull requests** with **CI green** before merge.
+- **Default for this repo:** use GitHub’s **merge commit** option (not squash-only) so PR boundaries stay visible in history. Write a clear **PR title** (and edit the merge commit subject when GitHub allows) so `git log` stays readable—conventional `type(scope):` titles are welcome when they fit.
+- **Squash merge** is fine for small, single-concern PRs when you want one commit on `main`.
+- Keep each PR focused on one concern; avoid unrelated drive-by changes in the same PR.
 
-- Default: **Squash merge** PRs with an edited final title that follows the commit format.
-- Keep PRs focused on one concern.
-- Avoid mixing merge styles (`Merge pull request...`, `Merge branch...`, custom `merge:` commits) in normal flow.
-- If a direct merge commit is required, use a clear conventional title.
+## Optional tooling (Cursor)
+
+If you use **Cursor’s Agent** for commits or pull requests, turn off **Settings → Agent → Attribution** so commit messages are not appended with a vendor trailer ([Cursor Git integration](https://cursor.com/docs/integrations/git)).
 
 ## Author Identity Checklist
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Screenshots from the production deployment (1280px viewport).
 
 ## Getting Started
 
+Clone into a folder name that matches the npm package name (`mmaitland-portfolio` in `package.json`). The GitHub repository slug may still be `webproject` until you rename the remote repo.
+
 ```powershell
-git clone https://github.com/mmaitland300/webproject.git
-cd webproject
+git clone https://github.com/mmaitland300/webproject.git mmaitland-portfolio
+cd mmaitland-portfolio
 Copy-Item .env.example .env   # PowerShell; then fill in values (see below)
 npm install            # also runs prisma generate via postinstall
 npm run dev
@@ -139,13 +141,11 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## Contributing
 
-For merge policy, author identity checks, and copy/encoding guardrails, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For merge policy, author identity checks, copy/encoding guardrails, and optional tooling notes (e.g. Cursor Agent attribution), see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Use clear, imperative commit subjects (for example: `Fix contact rate limit when Redis is unavailable`). Avoid redeploy-only checkpoints and trailing vendor or tool-generated footer lines unless a policy explicitly requires them.
 
 Optional: from the repo root, run `git config commit.template .gitmessage` to use the shared [commit template](.gitmessage). The first line of the message must not start with `#` (Git strips comment lines). That template is a local reminder only—Git does not enforce commit message style.
-
-If you use Cursor's Agent for commits or PRs, turn off **Settings → Agent → Attribution** so messages are not appended with a vendor trailer ([Cursor Git integration](https://cursor.com/docs/integrations/git)).
 
 ## Git history
 


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md:** Document **merge commits** as the usual way PRs land on `main`, allow **squash** for small PRs, clarify commit-subject rules vs GitHub merge titles, and move **Cursor Agent attribution** guidance here under **Optional tooling**.
- **README.md:** Clone into **`mmaitland-portfolio`** so the working directory matches `package.json` `name`; note GitHub slug may still be `webproject`. Point Contributing section at CONTRIBUTING for Cursor/tooling; remove duplicate Cursor paragraph from README.