### PR TITLE
docs: drop Cursor Agent attribution notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,6 @@ Rules:
 - **Squash merge** is fine for small, single-concern PRs when you want one commit on `main`.
 - Keep each PR focused on one concern; avoid unrelated drive-by changes in the same PR.
 
-## Optional tooling (Cursor)
-
-If you use **Cursor’s Agent** for commits or pull requests, turn off **Settings → Agent → Attribution** so commit messages are not appended with a vendor trailer ([Cursor Git integration](https://cursor.com/docs/integrations/git)).
-
 ## Author Identity Checklist
 
 Before opening a PR or committing:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## Contributing
 
-For merge policy, author identity checks, copy/encoding guardrails, and optional tooling notes (e.g. Cursor Agent attribution), see [CONTRIBUTING.md](CONTRIBUTING.md).
+For merge policy, author identity checks, and copy/encoding guardrails, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Use clear, imperative commit subjects (for example: `Fix contact rate limit when Redis is unavailable`). Avoid redeploy-only checkpoints and trailing vendor or tool-generated footer lines unless a policy explicitly requires them.
 


### PR DESCRIPTION
Remove the Optional tooling (Cursor) section from CONTRIBUTING and the Cursor reference from the README Contributing blurb.