### PR TITLE
fix(portfolio): clarify Research Radar prototype status

### DIFF
--- a/src/app/(site)/projects/research-radar/page.tsx
+++ b/src/app/(site)/projects/research-radar/page.tsx
@@ -415,9 +415,9 @@ export default function ResearchRadarCaseStudyPage() {
         </section>
 
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
-          <h2 className="mb-3 text-xl font-semibold">Operational proof</h2>
+          <h2 className="mb-3 text-xl font-semibold">Public, reviewer-facing evidence</h2>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Operational evidence is public and reviewer-facing: repository
+            What you can verify without special access: repository
             history, linked tests, roadmap notes, and the screenshot baseline
             shown in the walkthrough above. Internal hosting
             details are intentionally omitted; the live prototype uses the stable

--- a/src/components/sections/case-study-evidence-footer.tsx
+++ b/src/components/sections/case-study-evidence-footer.tsx
@@ -5,6 +5,7 @@ import type { Project } from "@/content/projects";
 const statusLabel: Record<NonNullable<Project["status"]>, string> = {
   "in-progress": "In Progress",
   operational: "Operational",
+  "live-prototype": "Live prototype",
   shipped: "Shipped",
   archived: "Archived",
 };

--- a/src/components/sections/project-card.tsx
+++ b/src/components/sections/project-card.tsx
@@ -17,6 +17,7 @@ interface ProjectCardProps {
 const statusLabel: Record<NonNullable<Project["status"]>, string> = {
   "in-progress": "In Progress",
   operational: "Operational",
+  "live-prototype": "Live prototype",
   shipped: "Shipped",
   archived: "Archived",
 };

--- a/src/content/projects.test.ts
+++ b/src/content/projects.test.ts
@@ -66,6 +66,7 @@ describe("projects data integrity", () => {
     const allowedStatus = new Set([
       "in-progress",
       "operational",
+      "live-prototype",
       "shipped",
       "archived",
     ]);

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -10,7 +10,12 @@ const snakeDemoUrl = getSnakeDemoUrl();
 const researchRadarDemoUrl = getResearchRadarDemoUrl();
 
 export type ProjectCategory = "featured" | "experiment";
-export type ProjectStatus = "in-progress" | "operational" | "shipped" | "archived";
+export type ProjectStatus =
+  | "in-progress"
+  | "operational"
+  | "live-prototype"
+  | "shipped"
+  | "archived";
 export type ProofLinkKind = "repo" | "test" | "ci" | "post" | "artifact";
 
 export interface ProofLink {
@@ -115,7 +120,7 @@ export const projects: Project[] = [
       "I focused first on saving ranking runs, exposing signal breakdowns, and making the prototype understandable before pushing harder on more experimental ranking ideas.",
     outcome:
       "The current prototype includes materialized emerging and undercited recommendation feeds, a bridge preview/diagnostics surface, paper detail with similar papers, corpus-scoped trends, and an evaluation view for comparing output against simple baselines.",
-    status: researchRadarDemoUrl ? "operational" : "in-progress",
+    status: "live-prototype",
     evidence:
       "The strongest stable claim today is that the prototype makes its ranking behavior visible and understandable over a curated set of MIR and audio ML papers.",
     knownLimits:


### PR DESCRIPTION
- Project status: Live prototype (new live-prototype mapping)

- Case study: rename Operational proof section to public/reviewer evidence

## Summary

<!-- What does this PR change and why? -->

## Proof Check

<!-- For messaging or positioning changes: what proof got stronger, or what language got softer? -->

## Checklist

- [x] Lint, tests, and production build pass locally (`npm run lint`, `npm test`, `npm run build`)
- [x] If nav, focus, or keyboard behavior changed: ran `npx playwright test`
- [x] If public messaging changed: answered the proof check above and updated `docs/proof-audit.md` if needed
- [x] No secrets or local-only paths committed
