### PR TITLE
Chore/site copy cleanup research radar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ RESEND_API_KEY=
 CONTACT_FROM_EMAIL=
 CONTACT_TO_EMAIL=
 
-# Optional but recommended: Upstash Redis — enables server-side rate limits on contact/waitlist when
+# Optional but recommended: Upstash Redis enables server-side rate limits on contact/waitlist when
 # BOTH variables are non-empty. Leave blank for local smoke runs; see README env footnote [2] and SECURITY.md.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,7 +1,7 @@
-Short imperative summary — replace this entire line (~50 chars; do not start with #)
+Short imperative summary: replace this entire line (~50 chars; do not start with #)
 
 # Optional body after a blank line above. Wrap at ~72. Example: Fixes #123
 #
-# Git removes lines that start with # — your real subject must be on line 1 with no #.
+# Git removes lines that start with #. Your real subject must be on line 1 with no #.
 # Avoid: checkpoint / trigger redeploy-only commits; trailing vendor or tool footers
 # unless a project policy explicitly requires them.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Matt Maitland: Personal site & case studies
+# Matt Maitland — Personal site & case studies
 
 **Live site:** [www.mmaitland.dev](https://www.mmaitland.dev)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Matt Maitland — Personal site & case studies
+# Matt Maitland: Personal site & case studies
 
 **Live site:** [www.mmaitland.dev](https://www.mmaitland.dev)
 
@@ -94,7 +94,7 @@ Copy `.env.example` to `.env` and fill in the values.
 
 **Rows marked No** are only for **admin GitHub OAuth** (`AUTH_*`, `ADMIN_GITHUB_IDS`) and the optional **`NEXT_PUBLIC_RESUME_PDF_LINK_BASE`**. Leave them unset if you do not need those features; the app still runs and tests/build stay predictable. **Database-backed** admin inbox also needs real **Neon** URLs in the **Yes** Prisma rows (see **Database Setup (Optional)**), not just the auth vars.
 
-**Rows marked Yes** cover normal local or production use: public site URL, Resend for contact mail, and Prisma placeholders for `npm install` / `npm run build`. **Upstash** is optional but recommended for deployments that expect public traffic (see footnote [2]). **CI** stubs `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_SITE_URL` (`https://www.mmaitland.dev`, matching production canonical) and does not pass Resend or Redis secrets—the same idea as compiling a production build without those values in the environment.
+**Rows marked Yes** cover normal local or production use: public site URL, Resend for contact mail, and Prisma placeholders for `npm install` / `npm run build`. **Upstash** is optional but recommended for deployments that expect public traffic (see footnote [2]). **CI** stubs `DATABASE_URL`, `DIRECT_URL`, and `NEXT_PUBLIC_SITE_URL` (`https://www.mmaitland.dev`, matching production canonical) and does not pass Resend or Redis secrets: the same idea as compiling a production build without those values in the environment.
 
 | Variable | Required | Purpose |
 |---|---|---|

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -18,7 +18,7 @@ export default function AboutPage() {
         <SectionHeader
           eyebrow="About"
           title="Technical support specialist, practical software builder"
-          description="How customer-facing triage—observe, isolate, validate—shows up in the web apps, audio tools, and research prototypes I build outside my Auxillium role."
+          description="How customer-facing triage (observe, isolate, validate) shows up in the web apps, audio tools, and research prototypes I build outside my Auxillium role."
           className="mb-16"
         />
         <AboutContent publicEmail={getPublicContactEmail()} />

--- a/src/app/(site)/projects/full-swing-tech-support/page.tsx
+++ b/src/app/(site)/projects/full-swing-tech-support/page.tsx
@@ -81,7 +81,7 @@ const representativeIncident = [
   {
     label: "Fix pattern",
     detail:
-      "Run the approved WMI namespace repair batch process, reboot, and re-test Core communication from a clean baseline. In this incident pattern, Core recovered after restart. A changed remote-support ID after reboot was treated as an observed follow-up clue that local Windows management or support-session identity state had been repaired, reset, or reinitialized—not definitive proof of the exact subsystem that changed.",
+      "Run the approved WMI namespace repair batch process, reboot, and re-test Core communication from a clean baseline. In this incident pattern, Core recovered after restart. A changed remote-support ID after reboot was treated as an observed follow-up clue that local Windows management or support-session identity state had been repaired, reset, or reinitialized, not definitive proof of the exact subsystem that changed.",
   },
   {
     label: "What changed after",
@@ -143,7 +143,7 @@ export default function FullSwingCaseStudyPage() {
             Golf from TruGolf, supported in the same workflow. The case study is
             about how multi-layer issues get diagnosed with
             remote-only access, incomplete logs, and privacy limits on what can
-            be shared—where hardware, software, networking, and operating-system
+            be shared, where hardware, software, networking, and operating-system
             behavior frequently overlap.
           </p>
         </header>

--- a/src/app/(site)/projects/research-radar/page.tsx
+++ b/src/app/(site)/projects/research-radar/page.tsx
@@ -35,7 +35,7 @@ const mainSurfaces = [
   {
     title: "Trends in the current dataset",
     detail:
-      "The trends page reads momentum inside this corpus slice. This is helpful for tuning here, scoped to what the ranker actually sees.",
+      "The trends page shows which topics are gaining traction inside the papers the ranker is working with. Useful context for why something keeps surfacing in the feeds.",
   },
   {
     title: "Evaluation and comparison",
@@ -130,9 +130,9 @@ const screenshotGallery = [
 
 const currentState = {
   stable: [
-    "The centerpiece is materialized emerging and undercited feeds that show why items appear where they do, plus bridge diagnostics, not a validated bridge recommender family yet.",
+    "The two main feeds (emerging and undercited) are working and show you why each paper ranked where it did. Bridge is visible as a diagnostics surface, not a full recommender yet.",
     "Paper detail, trends, and evaluation are all working parts of the prototype.",
-    "The strongest current value is inspecting and comparing recommendations with the ranking logic in plain sight.",
+    "The most useful thing it does right now: you can see the ranking logic, compare runs, and check it against simpler sorts.",
   ],
   experimental: [
     "Bridge is a preview/diagnostics route: bridge signal is measured and shown, but in the current public run it is not weighted into final_score, so it should not be read as a validated bridge recommender.",
@@ -146,11 +146,8 @@ const currentState = {
   ],
 };
 
-const lessonsLearned = [
-  "Building explanation and versioning in early made it easier to compare changes and improve the system over time.",
-  "Keeping experimental features visible but off by default kept the core product more focused.",
-  "Evaluation stayed useful as a comparison grid; a single headline score never bought enough confidence on its own.",
-];
+const lessonsLearned =
+  "Building the explanation layer early turned out to matter more than I expected. Once each run stored why it ranked the way it did, comparing versions became straightforward instead of guesswork. Keeping bridge visible but clearly off by default also helped: the core flow stayed focused, and I could work on the experimental side without it polluting the main results. The evaluation page earned its place too. I kept expecting a single summary score to be enough, and it never was. Seeing the full comparison grid against simple sorts was always more honest.";
 
 export const metadata: Metadata = {
   title: "Research Radar: Explainable Discovery Prototype",
@@ -200,17 +197,14 @@ export default function ResearchRadarCaseStudyPage() {
             Research Radar: explainable discovery for MIR and audio ML papers
           </h1>
           <p className="mt-4 max-w-3xl text-muted-foreground">
-            Research Radar is a product-shaped prototype for MIR and audio ML,
-            not a proven production product. The goal is simple: make ranking
-            behavior inspectable, not hidden. You can move from emerging and
-            undercited feeds through evaluation, trends, and paper detail without
-            losing the reasoning behind the order.
-          </p>
-          <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground">
-            The live app is deployed separately from this case study. Bridge is a
-            preview/diagnostics route (signal measured; not weighted into
-            final_score in the current public run), while the core flow focuses on
-            explainable emerging/undercited feeds plus transparent baseline comparison.
+            Research Radar is a working prototype, not a finished product. The
+            goal is straightforward: ranked lists of MIR and audio ML papers
+            where you can see why each result landed where it did. You can move
+            from the main feed into a paper, check the evaluation against simpler
+            sorts, and follow trends in the current dataset without losing the
+            reasoning behind the order. The live app runs separately from this
+            case study; the bridge feature is visible as a diagnostics surface
+            but is not part of the main recommendation flow yet.
           </p>
           <div className="mt-8 flex flex-wrap items-center gap-3">
             <a
@@ -519,13 +513,7 @@ export default function ResearchRadarCaseStudyPage() {
 
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
           <h2 className="mb-3 text-xl font-semibold">Lessons learned</h2>
-          <div className="space-y-4">
-            {lessonsLearned.map((item) => (
-              <p key={item} className="text-sm leading-relaxed text-muted-foreground">
-                {item}
-              </p>
-            ))}
-          </div>
+          <p className="text-sm leading-relaxed text-muted-foreground">{lessonsLearned}</p>
         </section>
 
         <CaseStudyEvidenceFooter

--- a/src/app/(site)/projects/research-radar/page.tsx
+++ b/src/app/(site)/projects/research-radar/page.tsx
@@ -64,58 +64,66 @@ const technicalPoints = [
 
 const screenshotGallery = [
   {
-    title: "Step 1: Ranked feed with visible signals",
+    title: "Step 1: The ranked feed",
     src: "/images/projects/research-radar/recommended-emerging.png",
     route: "/recommended?family=emerging",
+    plainSummary:
+      "This is the main list. Each card shows a paper and a short breakdown of what pushed it up in the ranking for this snapshot. You don't have to take the order on faith.",
     inspectPoints: [
-      "Paper cards show score, family, topic labels, signal breakdown, run label, and snapshot version.",
-      'The useful claim is not “these are objectively the best MIR papers.” The useful claim is “the system exposes why each paper surfaced in this corpus snapshot.”',
+      "Pick any card and read the signal block below the title. That's the system's reasoning for that result.",
+      "The feed is either emerging (newer papers gaining traction in this set) or undercited (papers that look underappreciated relative to their signals).",
     ],
-    supports:
-      "Ranking behavior is inspectable and reviewable rather than hidden behind a black-box feed.",
-    doesNotProve:
-      "It does not prove human relevance quality across the full MIR/audio-ML field.",
+    conclude:
+      "The ranking isn't a black box. You can see what drove each result and compare runs when the code changes.",
+    limit:
+      "This is a curated slice of papers, not a comprehensive index of the field. It tells you what ranked highly here, not what's objectively best.",
     alt: "Research Radar recommended emerging page showing ranked paper cards with visible signal breakdowns",
   },
   {
-    title: "Step 2: Paper dossier and similar-papers pivot",
+    title: "Step 2: Paper detail and similar papers",
     src: "/images/projects/research-radar/paper-detail-similar.png",
     route: "/papers/https%3A%2F%2Fopenalex.org%2FW3093121331",
+    plainSummary:
+      "Click any card from the feed and you land here. You get the paper's full details, where it sat in the ranked list, and a set of similar papers so you can keep exploring without starting over.",
     inspectPoints: [
-      "Metadata, venue/year, citation count, topic labels, and where this paper sits in the pinned ranking run.",
-      "Similar papers (when embeddings are configured) as a second hop from a known anchor.",
+      "Venue, year, citation count, and topic tags are all in one place.",
+      "The similar papers section finds nearby results by content. Useful when one paper looks relevant and you want to see what else is around it.",
     ],
-    supports:
-      "You can move from a ranked row into a dossier and back out without losing the run context.",
-    doesNotProve:
-      "Similar-paper cosine similarity is not a human-labeled relevance benchmark; it is an inspectable retrieval convenience in this prototype.",
+    conclude:
+      "You can move from a ranked result to a full paper view and keep moving through related work without losing your place.",
+    limit:
+      "Similar papers are matched by content similarity, not hand-curated. Useful for navigation, not a quality judgment.",
     alt: "Research Radar paper detail page for GiantMIDI Piano showing metadata and similar papers",
   },
   {
-    title: "Step 3: Proxy evaluation vs citation/date baselines",
+    title: "Step 3: Evaluation against simpler sorts",
     src: "/images/projects/research-radar/evaluation-emerging.png",
     route: "/evaluation?family=emerging",
+    plainSummary:
+      "This is where I check whether the ranking is actually doing something useful. It puts the system's output next to the most obvious alternatives: sort by citation count, sort by date. If the ranking is adding value, you should be able to see it here.",
     inspectPoints: [
-      "Side-by-side lists or columns for ranked output versus simple citation-count and recency baselines.",
-      "Distribution-level and overlap-style checks that match what the API exposes today.",
+      "Compare which papers appear in the ranked list versus what you'd get from a simple sort by citations or recency.",
+      "Look at the overall shape, not just individual rows. Does the ranked list feel meaningfully different from the simple sorts?",
     ],
-    supports:
-      "You can sanity-check ranking behavior against scores everyone already understands, before making stronger quality claims.",
-    doesNotProve:
-      "This is not a temporal backtest or a hand-reviewed relevance benchmark unless/until those artifacts exist and are documented.",
+    conclude:
+      "A quick sanity check that the ranking is doing something beyond what a spreadsheet sort would give you.",
+    limit:
+      "This is a comparison against simple baselines, not a formal relevance benchmark. A useful starting point, not a final verdict.",
     alt: "Research Radar evaluation page comparing ranked output against citation and date baselines",
   },
   {
-    title: "Step 4: Corpus-scoped trends",
+    title: "Step 4: Trends in this dataset",
     src: "/images/projects/research-radar/trends.png",
     route: "/trends",
+    plainSummary:
+      "The trends page shows which topics are picking up momentum inside this particular set of papers. Not the whole field, just what the ranker actually sees.",
     inspectPoints: [
-      "Topic momentum inside the same corpus snapshot the ranker sees, not OpenAlex-wide popularity.",
+      "Topic clusters gaining momentum within this snapshot. Useful for understanding why certain papers are surfacing in the emerging feed.",
     ],
-    supports:
-      "Trends give local context for why a topic cluster might be heating up inside this slice.",
-    doesNotProve:
-      "It does not prove global field trends outside the curated ingest.",
+    conclude:
+      "Gives context for why a topic might be heating up in the ranked lists right now.",
+    limit:
+      "This reflects momentum inside the curated set only. It won't match broader field trends.",
     alt: "Research Radar trends page showing topic momentum inside the curated corpus slice",
   },
 ];
@@ -291,10 +299,14 @@ export default function ResearchRadarCaseStudyPage() {
             <h2 className="text-xl font-semibold">Visual walkthrough</h2>
           </div>
           <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
-            Each step lists a route, what to look at in the UI, what honest claim
-            that view supports, and what it still does not prove. Screenshots come
-            from the live prototype and follow the usual review path: ranked feed,
-            dossier, proxy evaluation, then corpus-scoped trends.
+            Most paper tools give you a sorted list and no explanation of why
+            anything landed where it did. I built this partly to fix that and
+            partly to understand what it actually takes to build something like
+            this end to end. The way I use it: open the emerging or undercited
+            feed, read the signal note on each card before trusting the order,
+            click into a paper if it looks worth following, then check the
+            evaluation page to see whether the ranking makes sense against
+            simpler sorts like citation count or date.
           </p>
           <div className="space-y-6">
             {screenshotGallery.map((target) => {
@@ -333,23 +345,30 @@ export default function ResearchRadarCaseStudyPage() {
                         </code>
                       )}
                     </div>
+                    {"plainSummary" in target && (
+                      <p className="mt-2 text-muted-foreground">{target.plainSummary}</p>
+                    )}
                     <div className="mt-3 space-y-3 text-muted-foreground">
                       <div>
-                        <p className="font-medium text-foreground">What to inspect</p>
+                        <p className="font-medium text-foreground">What to look at</p>
                         <ul className="mt-1 list-disc pl-5">
                           {target.inspectPoints.map((pt) => (
                             <li key={pt}>{pt}</li>
                           ))}
                         </ul>
                       </div>
-                      <p>
-                        <span className="font-medium text-foreground">What this supports:</span>{" "}
-                        {target.supports}
-                      </p>
-                      <p>
-                        <span className="font-medium text-foreground">What this does not prove:</span>{" "}
-                        {target.doesNotProve}
-                      </p>
+                      {"conclude" in target && (
+                        <p>
+                          <span className="font-medium text-foreground">What you can take from this:</span>{" "}
+                          {target.conclude}
+                        </p>
+                      )}
+                      {"limit" in target && (
+                        <p>
+                          <span className="font-medium text-foreground">{"What it doesn't tell you"}:</span>{" "}
+                          {target.limit}
+                        </p>
+                      )}
                     </div>
                   </figcaption>
                 </figure>

--- a/src/app/(site)/projects/research-radar/page.tsx
+++ b/src/app/(site)/projects/research-radar/page.tsx
@@ -110,7 +110,7 @@ const screenshotGallery = [
     src: "/images/projects/research-radar/trends.png",
     route: "/trends",
     inspectPoints: [
-      "Topic momentum inside the same corpus snapshot the ranker sees—not OpenAlex-wide popularity.",
+      "Topic momentum inside the same corpus snapshot the ranker sees, not OpenAlex-wide popularity.",
     ],
     supports:
       "Trends give local context for why a topic cluster might be heating up inside this slice.",
@@ -122,7 +122,7 @@ const screenshotGallery = [
 
 const currentState = {
   stable: [
-    "The centerpiece is materialized emerging and undercited feeds that show why items appear where they do, plus bridge diagnostics—not a validated bridge recommender family yet.",
+    "The centerpiece is materialized emerging and undercited feeds that show why items appear where they do, plus bridge diagnostics, not a validated bridge recommender family yet.",
     "Paper detail, trends, and evaluation are all working parts of the prototype.",
     "The strongest current value is inspecting and comparing recommendations with the ranking logic in plain sight.",
   ],

--- a/src/app/(site)/projects/research-radar/page.tsx
+++ b/src/app/(site)/projects/research-radar/page.tsx
@@ -25,7 +25,7 @@ const mainSurfaces = [
   {
     title: "Ranked recommendations",
     detail:
-      "Visitors can browse emerging papers, undercited papers, and a bridge preview route for diagnostics. Each list is generated ahead of time and includes enough detail to show why a paper was recommended.",
+      "Two main feeds: emerging papers and undercited papers. Each list is precomputed and every card includes enough context to show why that paper ranked where it did.",
   },
   {
     title: "Paper detail with similar papers",
@@ -48,7 +48,7 @@ const technicalPoints = [
   {
     title: 'Recommendations should answer "why is this here?"',
     detail:
-      "Each ranked list stores the signal mix that produced it, same as keeping scratchwork attached to the answer sheet. That makes regressions obvious when ranking code changes and gives another reviewer something concrete to react to.",
+      "Each ranked list stores the signal mix that produced it alongside the results. When the ranking code changes and something moves, you can check what actually shifted instead of guessing. It also gives anyone reviewing the work something concrete to push back on.",
   },
   {
     title: "Splitting the site from the prototype is intentional",
@@ -56,9 +56,9 @@ const technicalPoints = [
       "This page is the case study, while the prototype runs as its own app. Under the hood there is a Next.js frontend, a FastAPI backend, Postgres with pgvector for storage and similarity search, and Python jobs for ingest, ranking, and clustering. Keeping those pieces separate makes it easier to update the ranking workflow without turning every change into a full-site deploy.",
   },
   {
-    title: "Experimental ideas stay visible and clearly bounded",
+    title: "Experimental ideas stay visible and clearly labelled",
     detail:
-      "Some ideas are still exploratory, especially bridge-style cross-cluster signal. It stays visible as a preview/diagnostics surface with explicit framing; first-class recommender language waits until weighting and evaluation match the label.",
+      "Bridge is the main example: the signal is measured and shown in the UI, but it's not weighted into the final score yet, and it's clearly marked as a diagnostics surface rather than a finished feature. I'd rather show the work in progress than hide it.",
   },
 ];
 

--- a/src/app/(site)/projects/stringflux/page.tsx
+++ b/src/app/(site)/projects/stringflux/page.tsx
@@ -240,7 +240,7 @@ export default function StringFluxCaseStudyPage() {
         <section className="mb-10 rounded-xl border border-border bg-card/40 p-6">
           <h2 className="mb-2 text-xl font-semibold">Current Validation Checks</h2>
           <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
-            Informal development checks only—no published CPU or latency numbers
+            Informal development checks only; no published CPU or latency numbers
             yet. Benchmarking waits until the core behavior is feature-stable.
           </p>
           <div className="space-y-3">

--- a/src/app/(site)/stringflux/page.tsx
+++ b/src/app/(site)/stringflux/page.tsx
@@ -81,7 +81,7 @@ export default function StringFluxPage() {
           <p className="mt-3 text-center text-sm text-muted-foreground">
             Three interface layouts from the dev build: Core (primary controls
             only), Waveform (grain region editor), and Advanced (modulation matrix and
-            deeper shaping). Preset names visible in the captures are incidental—many
+            deeper shaping). Preset names visible in the captures are incidental; many
             presets will use these same panels. Mod-source envelope meters show live
             activity; polish is ongoing.
           </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,7 +115,7 @@
   --ring: oklch(0.556 0 0);
 
   /*
-   * Brand gradients — cyan ↔ violet family tuned to match .page-title / .hero-name,
+   * Brand gradients: cyan ↔ violet family tuned to match .page-title / .hero-name,
    * not Tailwind’s default purple-600 / cyan-600 pair.
    */
   --brand-cta-from: #5746d4;

--- a/src/components/easter-egg/catch-pixel-game.tsx
+++ b/src/components/easter-egg/catch-pixel-game.tsx
@@ -291,7 +291,7 @@ export function CatchPixelGame() {
         />
       </div>
       <p className="text-center text-xs text-muted-foreground">
-        Walls and ceiling bounce. Only the bottom is a miss—keep the paddle under
+        Walls and ceiling bounce. Only the bottom is a miss; keep the paddle under
         the cyan pixel.
       </p>
       <Link

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -100,7 +100,7 @@ export function Footer() {
             </a>
             <span className="text-muted-foreground">
               {" "}
-              — Next.js, TypeScript, Tailwind
+              · Next.js, TypeScript, Tailwind
             </span>
           </p>
         </div>

--- a/src/components/layout/spectrum-ribbon.tsx
+++ b/src/components/layout/spectrum-ribbon.tsx
@@ -6,7 +6,7 @@
  * motion stays slow and non-distracting.
  *
  * Vertical ticks sit at spatial quarter-periods of the fundamental (phase 2π·cycles·x),
- * like scope graticule lines—subsampled so the strip never gets visually noisy.
+ * like scope graticule lines, subsampled so the strip never gets visually noisy.
  */
 
 import {

--- a/src/components/sections/about-content.tsx
+++ b/src/components/sections/about-content.tsx
@@ -52,7 +52,7 @@ export function AboutContent({ publicEmail }: AboutContentProps) {
         </p>
         <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
           Those habits still apply when I work on my own projects: web apps,
-          audio tools, and music. I still care about naming real limits—remote
+          audio tools, and music. I still care about naming real limits: remote
           diagnosis with incomplete information, Windows and display stack
           overlap, real-time audio deadline pressure, and small-scope solo
           maintenance.

--- a/src/components/sections/featured-projects.tsx
+++ b/src/components/sections/featured-projects.tsx
@@ -13,8 +13,8 @@ export function FeaturedProjects() {
   const featured = getHomepageFeaturedProjects();
   const researchRadarDemoUrl = getResearchRadarDemoUrl();
   const featuredDescription = researchRadarDemoUrl
-    ? "StringFlux, Research Radar with a linked hosted prototype, and Full Swing support in public, plus case studies for this site, Snake Detector, and more on the projects page."
-    : "StringFlux, Research Radar (case study and repository as evidence), and Full Swing support in public, plus case studies for this site, Snake Detector, and more on the projects page.";
+    ? "Three live projects with public case studies: StringFlux, Research Radar, and Full Swing support. More on the projects page."
+    : "Three projects with public case studies and repositories: StringFlux, Research Radar, and Full Swing support. More on the projects page.";
 
   return (
     <section className="py-24 relative z-10">

--- a/src/components/sections/featured-projects.tsx
+++ b/src/components/sections/featured-projects.tsx
@@ -13,8 +13,8 @@ export function FeaturedProjects() {
   const featured = getHomepageFeaturedProjects();
   const researchRadarDemoUrl = getResearchRadarDemoUrl();
   const featuredDescription = researchRadarDemoUrl
-    ? "StringFlux, Research Radar with a linked hosted prototype, and Full Swing support in public—plus case studies for this site, Snake Detector, and more on the projects page."
-    : "StringFlux, Research Radar (case study and repository as evidence), and Full Swing support in public—plus case studies for this site, Snake Detector, and more on the projects page.";
+    ? "StringFlux, Research Radar with a linked hosted prototype, and Full Swing support in public, plus case studies for this site, Snake Detector, and more on the projects page."
+    : "StringFlux, Research Radar (case study and repository as evidence), and Full Swing support in public, plus case studies for this site, Snake Detector, and more on the projects page.";
 
   return (
     <section className="py-24 relative z-10">

--- a/src/components/sections/project-comments.tsx
+++ b/src/components/sections/project-comments.tsx
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { MessageSquare } from "lucide-react";
 import { parseAppEnv } from "@/lib/env";
 import { isAdminAuthConfigured } from "@/lib/feature-config";
@@ -52,7 +53,25 @@ export async function ProjectComments({
       createdAt: c.createdAt,
     }));
   } catch (error) {
-    console.error("ProjectComments: failed to load comments", error);
+    const missingProjectCommentTable =
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021" &&
+      (error.meta?.modelName === "ProjectComment" ||
+        String(error.message).includes("ProjectComment"));
+
+    if (missingProjectCommentTable) {
+      if (process.env.NODE_ENV === "production") {
+        console.error(
+          "ProjectComments: ProjectComment table missing; apply database migrations.",
+        );
+      } else {
+        console.warn(
+          "ProjectComments: ProjectComment table missing; run `npx prisma migrate dev` (or deploy migrations) to enable comments.",
+        );
+      }
+    } else {
+      console.error("ProjectComments: failed to load comments", error);
+    }
     loadFailed = true;
   }
 

--- a/src/content/blog/building-this-site.mdx
+++ b/src/content/blog/building-this-site.mdx
@@ -37,7 +37,7 @@ Tailwind v4 is a significant evolution. It ships as a single package, requires n
 
 ## Design Philosophy
 
-I wanted something between minimal-flat and neon-overload. The dark theme uses a single cyan–violet ramp (CSS variables for CTAs, accents, and links) so the look stays consistent without being distracting. Motion maps to hierarchy—scroll cues and hover states, nothing purely decorative.
+I wanted something between minimal-flat and neon-overload. The dark theme uses a single cyan–violet ramp (CSS variables for CTAs, accents, and links) so the look stays consistent without being distracting. Motion maps to hierarchy: scroll cues and hover states, nothing purely decorative.
 
 ### Key Design Decisions
 
@@ -65,4 +65,4 @@ export async function submitContact(
 
 Phase 2 added the blog you're reading now. Phase 3 brought database persistence with Prisma and Neon PostgreSQL, a contact inbox with archive/restore, and GitHub OAuth via Auth.js for admin access. A `/music` page with SoundCloud embeds was added outside the original roadmap.
 
-The site is live and under active iteration. The current focus is tightening copy so it stays specific—concrete verbs, fewer stock contrasts, less brochure cadence.
+The site is live and under active iteration. The current focus is tightening copy so it stays specific: concrete verbs, fewer stock contrasts, less brochure cadence.

--- a/src/content/blog/stringflux-oversampling-decision-log.mdx
+++ b/src/content/blog/stringflux-oversampling-decision-log.mdx
@@ -78,5 +78,5 @@ existing signal path. That refactor forced better separation in the engine and
 made behavior less fragile.
 
 The current direction remains disciplined scope over feature sprawl. The goal is
-a single playable grain voice across bands—one engine you can lean on in a mix
+a single playable grain voice across bands: one engine you can lean on in a mix
 instead of a stack of unrelated stompboxes.

--- a/src/content/blog/typescript-patterns.mdx
+++ b/src/content/blog/typescript-patterns.mdx
@@ -9,7 +9,7 @@ published: true
 
 ## Why Patterns Matter
 
-As I learn TypeScript more deeply, I keep finding patterns that make code safer and easier to reason about. These are the ones I currently reach for most often, with examples pulled from this site's codebase so the snippets use concrete imports—no toy `foo`/`bar` placeholders.
+As I learn TypeScript more deeply, I keep finding patterns that make code safer and easier to reason about. These are the ones I currently reach for most often, with examples pulled from this site's codebase so the snippets use concrete imports, not toy `foo`/`bar` placeholders.
 
 ## Discriminated Unions
 

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -111,7 +111,7 @@ export const projects: Project[] = [
     slug: "research-radar",
     title: "Research Radar",
     description:
-      "A product-shaped prototype for MIR and audio ML papers: materialized emerging and undercited rankings, bridge diagnostics (not a validated recommender family yet), paper detail, trends, and transparent evaluation.",
+      "A working prototype for MIR and audio ML papers: ranked emerging and undercited feeds where you can see why each result landed where it did, plus paper detail, trends, evaluation, and bridge diagnostics.",
     problem:
       "Paper discovery tools often hide why something surfaced. I wanted ranked lists where the signals are visible so you can compare versions without guessing what moved.",
     constraints:
@@ -119,12 +119,12 @@ export const projects: Project[] = [
     tradeoff:
       "I focused first on saving ranking runs, exposing signal breakdowns, and making the prototype understandable before pushing harder on more experimental ranking ideas.",
     outcome:
-      "The current prototype includes materialized emerging and undercited recommendation feeds, a bridge preview/diagnostics surface, paper detail with similar papers, corpus-scoped trends, and an evaluation view for comparing output against simple baselines.",
+      "The current prototype has working emerging and undercited feeds, paper detail with similar papers, a trends view, an evaluation page for comparing output against simple baselines, and bridge as a diagnostics surface.",
     status: "live-prototype",
     evidence:
       "The strongest stable claim today is that the prototype makes its ranking behavior visible and understandable over a curated set of MIR and audio ML papers.",
     knownLimits:
-      "Bridge is preview/diagnostics, not a validated recommender family; general semantic relevance is not the default score (embedding slice-fit may appear on pinned emerging runs when labeled); corpus remains narrower than the long-term plan.",
+      "Bridge is diagnostics only, not a full recommender; semantic similarity is not the default ranking signal (it may appear on certain runs when the UI labels it); the corpus is still narrower than the long-term plan.",
     proofLinks: [
       {
         label: "Research Radar case study",

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -240,7 +240,7 @@ export const projects: Project[] = [
     constraints:
       "Remote support, incomplete logs, frustrated users, mixed hardware/software/network symptoms, and privacy limits on public evidence.",
     tradeoff:
-      "More time upfront on isolation and logging pays back when the same failure signature shows up again—you reopen the checklist instead of re-deriving the path from memory.",
+      "More time upfront on isolation and logging pays back when the same failure signature shows up again: you reopen the checklist instead of re-deriving the path from memory.",
     role: "Technical support specialist at Auxillium. Scope is Full Swing simulator deployments plus Laser Shot and E6 Golf from TruGolf when those are part of the install.",
     outcome:
       "Built repeatable triage workflows that I now use across calibration, licensing, display, networking, and OS subsystems. Documented publicly as a case study.",

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -32,7 +32,7 @@ export type ResumeSkillTier = {
 };
 
 export const resumeSummary =
-  "Technical support specialist building reliable web tools, audio software, and research prototypes. Full-time I support Full Swing simulator environments through Auxillium (calibration, licensing, display, networking, and Windows behavior), usually with remote diagnosis and incomplete information. Outside of work I build web apps, develop StringFlux (JUCE/C++), and ship research-shaped prototypes like Research Radar, carrying the same habit of naming limits and evidence up front.";
+  "Technical support specialist building reliable web tools, audio software, and research prototypes. Full-time I support Full Swing simulator environments through Auxillium. Most issues come in remote, with incomplete logs and no direct hardware access, across calibration, licensing, display, networking, and Windows behavior. Outside of work I build web apps, develop StringFlux (JUCE/C++), and ship research-shaped prototypes like Research Radar, carrying the same habit of naming limits and evidence up front.";
 
 export const resumeSkillTiers: ResumeSkillTier[] = [
   {

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -32,7 +32,7 @@ export type ResumeSkillTier = {
 };
 
 export const resumeSummary =
-  "Technical support specialist building reliable web tools, audio software, and research prototypes. Full-time I support Full Swing simulator environments through Auxillium—calibration, licensing, display, networking, and Windows behavior—usually with remote diagnosis and incomplete information. Outside of work I build web apps, develop StringFlux (JUCE/C++), and ship research-shaped prototypes like Research Radar, carrying the same habit of naming limits and evidence up front.";
+  "Technical support specialist building reliable web tools, audio software, and research prototypes. Full-time I support Full Swing simulator environments through Auxillium (calibration, licensing, display, networking, and Windows behavior), usually with remote diagnosis and incomplete information. Outside of work I build web apps, develop StringFlux (JUCE/C++), and ship research-shaped prototypes like Research Radar, carrying the same habit of naming limits and evidence up front.";
 
 export const resumeSkillTiers: ResumeSkillTier[] = [
   {
@@ -79,7 +79,7 @@ export const resumeExperience: ResumeExperienceItem[] = [
     company: "Self-directed",
     period: "2022 - Present",
     description:
-      "Self-directed web and audio software with documented tradeoffs and public write-ups—scoped for nights-and-weekends time, solo maintenance, and the same incomplete-information habits as remote support.",
+      "Self-directed web and audio software with documented tradeoffs and public write-ups, scoped for nights-and-weekends time, solo maintenance, and the same incomplete-information habits as remote support.",
     highlights: [
       {
         text: "Built and shipped mmaitland.dev with typed content, CI, smoke tests, contact validation, rate limiting, and optional admin workflows.",

--- a/src/lib/site-nav.ts
+++ b/src/lib/site-nav.ts
@@ -1,4 +1,4 @@
-/** Primary IA links — shared by navbar and footer so labels and order stay aligned. */
+/** Primary IA links: shared by navbar and footer so labels and order stay aligned. */
 export const siteNavLinks = [
   { href: "/", label: "Home" },
   { href: "/projects", label: "Projects" },


### PR DESCRIPTION
## Summary

Cleaned up some writing on the page. Moving away from overly technical wording for better clarity.

## Checklist

- [x ] Lint, tests, and production build pass locally (`npm run lint`, `npm test`, `npm run build`)
- [x ] If nav, focus, or keyboard behavior changed: ran `npx playwright test`
- [x ] If public messaging changed: answered the proof check above and updated `docs/proof-audit.md` if needed
- [x ] No secrets or local-only paths committed
